### PR TITLE
Opengraph

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -8,7 +8,7 @@ export const metadata: Metadata = {
   keywords: "Minecraft社区, 加入翻译社区, Minecraft志愿者, 游戏翻译, 中文本地化",
     openGraph: {
     url: "https://pling.top/contact",
-    title: "联系我们 | PixelLingual像素语匠",
+    title: "联系我们 - PixelLingual像素语匠",
     description: "与PixelLingual取得联系，与志同道合的Minecraft爱好者一起翻译游戏内容，分享乐趣，共同成长。无论你是翻译爱好者、Minecraft玩家还是开发者，都能在这里找到归属。",
     images: "/logo-short.png",
   },

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
     url: "https://pling.top/contact",
     title: "联系我们 | PixelLingual像素语匠",
     description: "与PixelLingual取得联系，与志同道合的Minecraft爱好者一起翻译游戏内容，分享乐趣，共同成长。无论你是翻译爱好者、Minecraft玩家还是开发者，都能在这里找到归属。",
+    images: "/logo-short.png",
   },
   twitter: {
     card: "summary_large_image",

--- a/app/donate/page.tsx
+++ b/app/donate/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
   keywords: "Minecraft捐赠, 支持Minecraft翻译, PixelLingual支持者, Minecraft中文翻译",
   openGraph: {
     url: "https://pling.top/donate",
-    title: "支持我们 | PixelLingual像素语匠",
+    title: "支持我们 - PixelLingual像素语匠",
     description: "通过捐赠支持PixelLingual继续为社区提供高质量的Minecraft中文翻译。您的支持将帮助我们扩展翻译内容并提高质量。",
     images: "/logo-short.png",
   },

--- a/app/donate/page.tsx
+++ b/app/donate/page.tsx
@@ -16,6 +16,7 @@ export const metadata: Metadata = {
     url: "https://pling.top/donate",
     title: "支持我们 | PixelLingual像素语匠",
     description: "通过捐赠支持PixelLingual继续为社区提供高质量的Minecraft中文翻译。您的支持将帮助我们扩展翻译内容并提高质量。",
+    images: "/logo-short.png",
   },
   twitter: {
     card: "summary_large_image",

--- a/app/join-us/page.tsx
+++ b/app/join-us/page.tsx
@@ -12,6 +12,7 @@ export const metadata: Metadata = {
     url: "https://pling.top/join-us",
     title: "加入我们 | PixelLingual像素语匠",
     description: "加入PixelLingual社区，与志同道合的Minecraft爱好者一起翻译游戏内容，分享乐趣，共同成长。无论你是翻译爱好者、Minecraft玩家还是开发者，都能在这里找到归属。",
+    images: "/logo-short.png",
   },
   twitter: {
     card: "summary_large_image",

--- a/app/join-us/page.tsx
+++ b/app/join-us/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
   keywords: "Minecraft社区, 加入翻译社区, Minecraft志愿者, 游戏翻译, 中文本地化",
   openGraph: {
     url: "https://pling.top/join-us",
-    title: "加入我们 | PixelLingual像素语匠",
+    title: "加入我们 - PixelLingual像素语匠",
     description: "加入PixelLingual社区，与志同道合的Minecraft爱好者一起翻译游戏内容，分享乐趣，共同成长。无论你是翻译爱好者、Minecraft玩家还是开发者，都能在这里找到归属。",
     images: "/logo-short.png",
   },

--- a/app/market/[id]/page.tsx
+++ b/app/market/[id]/page.tsx
@@ -33,9 +33,9 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   return {
     title: `${pack.title}翻译包 | PixelLingual像素语匠`,
     description: pack.description,
-    keywords: `${pack.title} 中文翻译, ${pack.tags.join(", ")}, Minecraft基岩版翻译, ${pack.studio} 翻译`,
+    keywords: `${pack.title} 中文翻译, ${pack.tags.join(", ")}, Minecraft基岩版翻译, ${pack.studio} 翻译下载`,
     openGraph: {
-      title: `${pack.title} - PixelLingual`,
+      title: `${pack.title}翻译包 - PixelLingual像素语匠`,
       description: pack.description,
       images: [pack.image], // 确保 image 属性是一个 URL 字符串
       type: "article",

--- a/app/market/[id]/page.tsx
+++ b/app/market/[id]/page.tsx
@@ -1,533 +1,95 @@
-"use client"
+import { Metadata } from 'next'; 
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
-import { useState, useEffect, use } from "react"
-import Image from "next/image"
-import Link from "next/link"
-import { ArrowLeft, Calendar, Star, Share2, Globe, ChevronLeft, ChevronRight } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import DisclaimerPopup from "@/components/disclaimer-popup"
-import BackToTop from "@/components/back-to-top"
 import {
   getPackById,
   getPacksByStudio,
   getPacksByTag,
-  formatDate,
-  getLanguageDisplayName,
-  TranslationPack,
-} from "@/data/translation-packs"
-import TranslationPackCard from "@/components/translation-pack-card"
-import StarRating from "@/components/star-rating"
-import { STUDIOS } from "@/data/translation-packs"
-import { useRouter } from "next/navigation"
-import Head from "next/head"
+  TranslationPack, // 导入 TranslationPack 类型
+} from "@/data/translation-packs";
+// 注意：这里不再需要客户端相关的 hooks 和组件
 
 interface PageProps {
   params: {
-    id: string
-  }
+    id: string;
+  };
 }
 
-export default function TranslationPackDetailPage({ params }: PageProps) {
-  const { id } = use(params)
-  const router = useRouter()
-  const [pack, setPack] = useState<TranslationPack | null>(null)
-  const [studioPacks, setStudioPacks] = useState<TranslationPack[] | []>([])
-  const [similarPacks, setSimilarPacks] = useState<TranslationPack[] | []>([])
-  const [isDisclaimerOpen, setIsDisclaimerOpen] = useState(false)
-  const [currentScreenshot, setCurrentScreenshot] = useState(0)
+// --------------------------------------------------------
+// 1. generateMetadata 函数 (用于服务器端生成 <head> 标签)
+// --------------------------------------------------------
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { id: packId } = await params;
+  const pack = getPackById(packId);
 
-  // Scroll to top on page load
-  useEffect(() => {
-    window.scrollTo(0, 0)
-  }, [id])
-
-  useEffect(() => {
-    // Get pack data
-    const packId = id
-    const packData = getPackById(packId)
-
-    if (packData) {
-      setPack(packData)
-
-      // 动态设置页面标题
-      document.title = `${packData.title} | PixelLingual像素语匠`
-
-      // Get more from this studio
-      const studioPacksData = getPacksByStudio(packData.studio, packId).slice(0, 4)
-      setStudioPacks(studioPacksData)
-
-      // Get similar packs based on tags
-      if (packData.tags.length > 0) {
-        // Get a random tag from the pack
-        const randomTag = packData.tags[Math.floor(Math.random() * packData.tags.length)]
-        const tagPacksData = getPacksByTag(randomTag, packId).slice(0, 4)
-        setSimilarPacks(tagPacksData)
-      }
-    } else {
-      document.title = "翻译包未找到 | PixelLingual像素语匠"
-    }
-  }, [id])
-
-  const handleDownloadClick = () => {
-    // Check if disclaimer has been accepted before
-    const disclaimerAccepted = localStorage.getItem("disclaimerAccepted") === "true"
-
-    if (disclaimerAccepted) {
-      // Proceed directly to download
-      if (pack)
-        window.open(pack.downloadLink, "_blank")
-    } else {
-      // Show disclaimer popup
-      setIsDisclaimerOpen(true)
-    }
+  if (!pack) {
+    return {
+      title: "翻译包未找到 | PixelLingual像素语匠",
+      description: "您查找的翻译包不存在或已被移除。",
+    };
   }
 
-  const handleDisclaimerAccept = () => {
-    setIsDisclaimerOpen(false)
-    // Proceed to download
-    if (pack)
-      window.open(pack.downloadLink, "_blank")
-  }
+  return {
+    title: `${pack.title}翻译包 | PixelLingual像素语匠`,
+    description: pack.description,
+    keywords: `${pack.title} 中文翻译, ${pack.tags.join(", ")}, Minecraft基岩版翻译, ${pack.studio} 翻译`,
+    openGraph: {
+      title: `${pack.title} - PixelLingual`,
+      description: pack.description,
+      images: [pack.image], // 确保 image 属性是一个 URL 字符串
+      type: "article",
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${pack.title} - PixelLingual`,
+      description: pack.description,
+      images: [pack.image], // 确保 image 属性是一个 URL 字符串
+    },
+  };
+}
 
-  const handleShare = () => {
-    if (navigator.share) {
-      if (pack){
-      navigator
-        .share({
-          title: pack.title,
-          text: `Check out this Minecraft translation pack: ${pack.title}`,
-          url: window.location.href,
-        })
-        .catch((error) => console.log("Error sharing", error))
-      }
-    } else {
-      // Fallback for browsers that don't support the Web Share API
-      navigator.clipboard
-        .writeText(window.location.href)
-        .then(() => {
-          alert("链接已复制至剪贴板!")
-        })
-        .catch((err) => {
-          console.error("Could not copy text: ", err)
-        })
-    }
-  }
-  // 处理截图导航
-  const nextScreenshot = () => {
-    if (pack && pack.screenshots && pack.screenshots.length > 0) {
-      setCurrentScreenshot((prev) => (prev + 1) % pack.screenshots.length)
-    }
-  }
+// --------------------------------------------------------
+// 2. 页面组件 (服务器组件)
+// --------------------------------------------------------
+import TranslationPackDetailClient from "./translation-pack-detail-client"; 
 
-  const prevScreenshot = () => {
-    if (pack && pack.screenshots && pack.screenshots.length > 0) {
-      setCurrentScreenshot((prev) => (prev - 1 + pack.screenshots.length) % pack.screenshots.length)
-    }
-  }
+export default async function TranslationPackDetailPage({ params }: PageProps) {
+  const { id: packId } = await params;
+
+  const pack = getPackById(packId);
+
+  // 处理翻译包未找到的情况 (服务器端渲染)
   if (!pack) {
     return (
-      <>
-        <Head>
-          <title>翻译包未找到 | PixelLingual像素语匠</title>
-          <meta name="description" content="您查找的翻译包不存在或已被移除。" />
-        </Head>
       <div className="container py-20 text-center">
         <h2 className="text-2xl font-pixel mb-4">翻译包未找到</h2>
         <p className="text-muted-foreground mb-8">
-        您正在寻找的翻译包不存在或因某些原因已被移除。
+          您正在寻找的翻译包不存在或因某些原因已被移除。
         </p>
         <Button asChild className="minecraft-btn">
           <Link href="/market">返回市场</Link>
         </Button>
       </div>
-      </>
-    )
+    );
   }
 
-  // Calculate star rating display
-  const fullStars = Math.floor(pack.rating)
-  const hasHalfStar = pack.rating % 1 >= 0.5
-  const emptyStars = 5 - fullStars - (hasHalfStar ? 1 : 0)
-  const ratingPercentage = (pack.rating / 5) * 100
-  const studio = STUDIOS.find((studio) => studio.id === pack.studio);
-  const screenshots = pack.screenshots || []
+  // 在服务器端获取相关联的数据
+  const studioPacksData = getPacksByStudio(pack.studio, pack.id).slice(0, 4);
+  let similarPacksData: TranslationPack[] = [];
+  if (pack.tags.length > 0) {
+    const randomTag = pack.tags[Math.floor(Math.random() * pack.tags.length)];
+    similarPacksData = getPacksByTag(randomTag, pack.id).slice(0, 4);
+  }
 
+  // 将获取到的数据作为 prop 传递给客户端组件
   return (
-    <>
-      <Head>
-        <title>{pack.title}翻译包 | PixelLingual像素语匠</title>
-        <meta name="description" content={pack.description} />
-        <meta
-          name="keywords"
-          content={`${pack.title} 中文翻译, ${pack.tags.join(", ")}, Minecraft基岩版翻译, ${pack.studio} 翻译`}
-        />
-        <meta property="og:title" content={`${pack.title} - PixelLingual`} />
-        <meta property="og:description" content={pack.description} />
-        <meta property="og:image" content={pack.image} />
-        <meta property="og:type" content="article" />
-        <meta name="twitter:card" content="summary_large_image" />
-        <meta name="twitter:title" content={`${pack.title} - PixelLingual`} />
-        <meta name="twitter:description" content={pack.description} />
-        <meta name="twitter:image" content={pack.image} />
-      </Head>
-    <div className="min-h-screen pb-20">
-      {/* Hero Section */}
-      <section className="relative py-8 animate-fade-in">
-        <div className="container">
-          <Link href="/market" className="inline-flex items-center text-muted-foreground hover:text-primary mb-4">
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            回到市场
-          </Link>
-
-          <div className="grid md:grid-cols-2 gap-8">
-            <div className="minecraft-card overflow-hidden">
-              {pack.isDLC && (
-                <div className="absolute top-4 left-4 z-10">
-                  <span className="bg-yellow-500 text-black font-pixel px-3 py-1">DLC</span>
-                </div>
-              )}
-              <Image
-                src={pack.image || "/placeholder.svg"}
-                alt={pack.title}
-                width={600}
-                height={400}
-                className="w-full h-auto object-cover"
-              />
-            </div>
-
-            <div className="space-y-6">
-              <div>
-                <div className="flex flex-wrap gap-2 mb-2">
-                  {pack.tags.map((tag) => (
-                    <Link href={`/market/tag/${tag.toLowerCase()}`} key={tag}>
-                      <span className="tag-pill">{tag}</span>
-                    </Link>
-                  ))}
-                </div>
-                <h1 className="text-3xl font-pixel">{pack.title}</h1>
-                <p className="text-muted-foreground mt-2">{pack.description}</p>
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
-                <div className="minecraft-card p-3">
-                  <div className="flex items-center text-muted-foreground mb-1">
-                    <Star className="h-4 w-4 mr-1" />
-                    <span className="text-sm">评分</span>
-                  </div>
-                  <div className="flex items-center">
-                    <StarRating rate={pack.rating} />
-                    <span className="ml-2 font-pixel text-lg">{pack.rating.toFixed(1)}</span>
-                  </div>
-                </div>
-
-                <div className="minecraft-card p-3">
-                  <div className="flex items-center text-muted-foreground mb-1">
-                    <Calendar className="h-4 w-4 mr-1" />
-                    <span className="text-sm">更新时间</span>
-                  </div>
-                  <p className="font-pixel text-lg">{formatDate(pack.updatedAt)}</p>
-                </div>
-
-                <div className="minecraft-card p-3">
-                  <div className="flex items-center text-muted-foreground mb-1">
-                    <Globe className="h-4 w-4 mr-1" />
-                    <span className="text-sm">翻译语言</span>
-                  </div>
-                  <div className="flex flex-wrap gap-1">
-                    {pack.languages.map((lang) => (
-                      <span key={lang} className="text-xs px-2 py-1 rounded">
-                        {getLanguageDisplayName(lang)}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="minecraft-card p-3">
-                  <div className="flex items-center text-muted-foreground mb-1">
-                    <span className="text-sm">地图价格</span>
-                  </div>
-                  <p className="font-pixel text-lg">{pack.price === 0 ? "免费" : `${pack.price} MC`}</p>
-                </div>
-              </div>
-
-              <div className="flex flex-col sm:flex-row gap-4">
-                <Button className="minecraft-btn flex-1 justify-center" onClick={handleDownloadClick}>
-                  下载翻译包
-                </Button>
-                <Button variant="outline" size="icon" onClick={handleShare}>
-                  <Share2 className="h-5 w-5" />
-                  <span className="sr-only">分享</span>
-                </Button>
-              </div>
-
-              <div className="grid grid-cols-2 gap-x-8 gap-y-2 text-sm">
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">翻译作者:</span>
-                  <span>{pack.author}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">地图工作室:</span>
-                  <Link
-                    href={`/market/studio/${pack.studio.toLowerCase().replace(/\s+/g, "-")}`}
-                    className="hover:text-primary"
-                  >
-                    {studio ? studio.name : "无名氏"}
-                  </Link>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-muted-foreground">发布时间:</span>
-                  <span>{formatDate(pack.createdAt)}</span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Content Tabs */}
-      <section className="py-8 animate-fade-in animate-delay-100">
-        <div className="container">
-          <Tabs defaultValue="details">
-            <TabsList className="grid w-full grid-cols-3 mb-2">
-              <TabsTrigger value="details" className="font-pixel text-xs sm:text-sm">
-                详情
-              </TabsTrigger>
-              <TabsTrigger value="screenshots" className="font-pixel text-xs sm:text-sm">
-                截图
-              </TabsTrigger>
-              <TabsTrigger value="installation" className="font-pixel text-xs sm:text-sm">
-                安装
-              </TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="details" className="mt-6">
-              <div className="minecraft-card p-6">
-                <h2 className="text-xl font-pixel mb-4">包含内容</h2>
-                <p>{pack.description}</p>
-                <ul className="space-y-2">
-                  {pack.features.map((feature, index) => (
-                    <li key={index} className="flex items-start">
-                      <span className="text-primary mr-2">•</span>
-                      <span>{feature}</span>
-                    </li>
-                  ))}
-                </ul>
-
-                <h2 className="text-xl font-pixel mt-8 mb-4">简介</h2>
-                <div className="space-y-4">
-                  <p>
-                    该汉化包是市场包地图 {pack.title} 的翻译资源包，使用本资源包即可使用中文游玩地图。
-                  </p>
-                  <p>
-                    翻译作者对游戏的各个方面进行了精心翻译，确保保留原意和细微差别，同时使其自然流畅地翻译成中文。我们特别关注游戏特定的术语，并始终保持一致性。如有发现任何翻译错误或不规范，欢迎通过 Fanconma@gmail.com 或其他方式提出。
-                  </p>
-                </div>
-
-                <h2 className="text-xl font-pixel mt-8 mb-4">翻译语言</h2>
-                <div className="space-y-2">
-                  {pack.languages.map((lang) => (
-                    <div key={lang} className="flex items-center">
-                      <span className="text-primary mr-2">•</span>
-                      <span>{getLanguageDisplayName(lang)}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </TabsContent>
-
-            <TabsContent value="screenshots" className="mt-6">
-              <div className="minecraft-card p-6">
-                <h2 className="text-xl font-pixel mb-4">截图</h2>
-                
-                {screenshots.length > 0 ? (
-                  <div className="space-y-6">
-                    {/* 主要截图展示 */}
-                    <div className="relative minecraft-card overflow-hidden">
-                      <div className="aspect-video relative">
-                        <Image
-                          src={screenshots[currentScreenshot] || `/placeholder.svg?height=400&width=600&text=${pack.title} Screenshot`}
-                          alt={`Screenshot ${currentScreenshot + 1}`}
-                          fill
-                          className="object-cover"
-                        />
-                      </div>
-                      
-                      {/* 导航按钮 */}
-                      {screenshots.length > 1 && (
-                        <>
-                          <Button 
-                            variant="outline" 
-                            size="icon" 
-                            className="absolute left-2 top-1/2 -translate-y-1/2 z-10 bg-background/80 backdrop-blur-sm rounded-full"
-                            onClick={prevScreenshot}
-                          >
-                            <ChevronLeft className="h-4 w-4" />
-                            <span className="sr-only">前一张截图</span>
-                          </Button>
-                          
-                          <Button 
-                            variant="outline" 
-                            size="icon" 
-                            className="absolute right-2 top-1/2 -translate-y-1/2 z-10 bg-background/80 backdrop-blur-sm rounded-full"
-                            onClick={nextScreenshot}
-                          >
-                            <ChevronRight className="h-4 w-4" />
-                            <span className="sr-only">下一张截图</span>
-                          </Button>
-                        </>
-                      )}
-                      
-                      {/* 截图计数器 */}
-                      <div className="absolute bottom-2 right-2 bg-background/80 backdrop-blur-sm px-2 py-1 rounded text-xs">
-                        {currentScreenshot + 1} / {screenshots.length}
-                      </div>
-                    </div>
-                    
-                    {/* 缩略图导航 */}
-                    {screenshots.length > 1 && (
-                      <div className="grid grid-cols-4 sm:grid-cols-6 gap-2">
-                        {screenshots.map((screenshot, index) => (
-                          <button
-                            key={index}
-                            title="继续"
-                            className={`minecraft-card overflow-hidden ${index === currentScreenshot ? 'ring-2 ring-primary' : ''}`}
-                            onClick={() => setCurrentScreenshot(index)}
-                          >
-                            <div className="aspect-video relative">
-                              <Image
-                                src={screenshot || `/placeholder.svg?height=100&width=150&text=Thumb ${index + 1}`}
-                                alt={`Thumbnail ${index + 1}`}
-                                fill
-                                className="object-cover"
-                              />
-                            </div>
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                ) : (
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    {[1, 2, 3].map((index) => (
-                      <div key={index} className="minecraft-card overflow-hidden">
-                        <Image
-                          src={`/placeholder.svg?height=400&width=600&text=${pack.title} Screenshot ${index}`}
-                          alt={`Screenshot ${index}`}
-                          width={600}
-                          height={400}
-                          className="w-full h-auto object-cover"
-                        />
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            </TabsContent>
-
-            <TabsContent value="installation" className="mt-6">
-              <div className="minecraft-card p-6">
-                <h2 className="text-xl font-pixel mb-4">翻译包安装说明</h2>
-                <ol className="space-y-4">
-                  {[
-                    "下载.mcpack后缀的资源包文件",
-                    "选择\"使用 Minecraft 打开\"该紫云阿宝文件",
-                    "进入对应市场地图的创建页面",
-                    '点击蓝色背景的\"解锁设置\"',
-                    "进入资源包页面并激活对应的汉化资源包",
-                  ].map((step, index) => (
-                    <li key={index} className="flex items-start">
-                      <span className="font-pixel text-primary mr-2">{index + 1}.</span>
-                      <span>{step}</span>
-                    </li>
-                  ))}
-                </ol>
-
-                <div className="mt-8 p-4 bg-muted/50 rounded-md">
-                  <h3 className="font-pixel text-lg mb-2">故障排除</h3>
-                  <p className="mb-4">如果您在使用翻译包时遇到任何问题，请尝试以下操作：</p>
-                  <ul className="space-y-2">
-                  <li className="flex items-start">
-                      <span className="text-primary mr-2">•</span>
-                      <h2>蓝奏云下载时要点开汉化包文件才可直接下载</h2>
-                    </li>
-                    <li className="flex items-start">
-                      <span className="text-primary mr-2">•</span>
-                      <span>确保你使用的 Minecraft 版本兼容地图</span>
-                    </li>
-                    <li className="flex items-start">
-                      <span className="text-primary mr-2">•</span>
-                      <span>确保你的语言是汉化包所对应的语言而不是其他语言（例如汉化包不支持繁体中文而你正在使用繁体中文）</span>
-                    </li>
-                    <li className="flex items-start">
-                      <span className="text-primary mr-2">•</span>
-                      <span>尝试将汉化资源包放于所有资源包的顶端</span>
-                    </li>
-                    <li className="flex items-start">
-                      <span className="text-primary mr-2">•</span>
-                      <span>
-                        浏览我们的{" "}
-                        <Link href="/troubleshooting" className="text-primary hover:underline">
-                          故障排除界面
-                        </Link>{" "}
-                        获取更多帮助
-                      </span>
-                    </li>
-                  </ul>
-                </div>
-
-                <div className="mt-8">
-                  <Button className="minecraft-btn w-full justify-center" onClick={handleDownloadClick}>
-                    下载翻译包
-                  </Button>
-                </div>
-              </div>
-            </TabsContent>
-          </Tabs>
-        </div>
-      </section>
-
-      {/* More from this Studio */}
-      {studioPacks.length > 0 && (
-        <section className="py-8 animate-fade-in animate-delay-200">
-          <div className="container">
-            <h2 className="text-2xl font-pixel mb-6">更多来自 {studio ? studio.name : "无名氏"} 的地图翻译包</h2>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-              {studioPacks.map((studioPack) => (
-                <TranslationPackCard key={studioPack.id} pack={studioPack} />
-              ))}
-            </div>
-          </div>
-        </section>
-      )}
-
-      {/* Similar Translations */}
-      {similarPacks.length > 0 && (
-        <section className="py-8 animate-fade-in animate-delay-300">
-          <div className="container">
-            <h2 className="text-2xl font-pixel mb-6">类似地图的汉化包</h2>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-              {similarPacks.map((similarPack) => (
-                <TranslationPackCard key={similarPack.id} pack={similarPack} />
-              ))}
-            </div>
-          </div>
-        </section>
-      )}
-
-      {/* Disclaimer Popup */}
-      <DisclaimerPopup
-        isOpen={isDisclaimerOpen}
-        onClose={() => setIsDisclaimerOpen(false)}
-        onAccept={handleDisclaimerAccept}
-        packTitle={pack.title}
-      />
-
-      {/* Back to Top Button */}
-      <BackToTop />
-    </div>
-    </>
-  )
+    <TranslationPackDetailClient
+      initialPack={pack}
+      initialStudioPacks={studioPacksData}
+      initialSimilarPacks={similarPacksData}
+    />
+  );
 }
+
+// 注意：格式化日期函数不再需要在 `page.tsx` 中，因为现在它在 `translation-pack-detail-client.tsx` 中使用。

--- a/app/market/[id]/translation-pack-detail-client.tsx
+++ b/app/market/[id]/translation-pack-detail-client.tsx
@@ -1,0 +1,485 @@
+"use client"; 
+
+import { useState, useEffect } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowLeft, Calendar, Star, Share2, Globe, ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import DisclaimerPopup from "@/components/disclaimer-popup";
+import BackToTop from "@/components/back-to-top";
+// 注意：这里不再需要 getPackById, getPacksByStudio, getPacksByTag，因为数据是从服务器组件传入的
+import {
+  getLanguageDisplayName,
+  TranslationPack, // 导入类型
+} from "@/data/translation-packs";
+import TranslationPackCard from "@/components/translation-pack-card";
+import StarRating from "@/components/star-rating";
+import { STUDIOS } from "@/data/translation-packs";
+import { useRouter } from "next/navigation";
+
+// 格式化日期函数
+const formatDate = (dateString: string | undefined | null) => {
+  if (!dateString) {
+    return "N/A"; // 如果日期字符串为空或 null/undefined，返回 "N/A"
+  }
+
+  // 假设 dateString 是 "YYYYMMDD" 格式，例如 "20220217"
+  // 将其转换为 "YYYY-MM-DD" 格式，例如 "2022-02-17"
+  // 使用正则表达式匹配年、月、日，并用破折号连接
+  const formattedDateString = dateString.replace(
+    /(\d{4})(\d{2})(\d{2})/,
+    '$1-$2-$3'
+  );
+
+  const date = new Date(formattedDateString);
+
+  // 检查日期对象是否有效 (getTime() 返回 NaN 表示无效日期)
+  if (isNaN(date.getTime())) {
+    return "无效日期格式"; // 如果仍然无法解析，返回一个友好的错误提示
+  }
+
+  // 使用 toLocaleDateString 进行格式化
+  return date.toLocaleDateString("zh-CN", { year: "numeric", month: "long", day: "numeric" });
+};
+
+interface TranslationPackDetailClientProps {
+  initialPack: TranslationPack;
+  initialStudioPacks: TranslationPack[];
+  initialSimilarPacks: TranslationPack[];
+}
+
+export default function TranslationPackDetailClient({
+  initialPack,
+  initialStudioPacks,
+  initialSimilarPacks,
+}: TranslationPackDetailClientProps) {
+  const router = useRouter();
+  // 使用从 props 传入的初始数据初始化状态
+  const [pack, setPack] = useState<TranslationPack>(initialPack);
+  const [studioPacks, setStudioPacks] = useState<TranslationPack[]>(initialStudioPacks);
+  const [similarPacks, setSimilarPacks] = useState<TranslationPack[]>(initialSimilarPacks);
+  const [isDisclaimerOpen, setIsDisclaimerOpen] = useState(false);
+  const [currentScreenshot, setCurrentScreenshot] = useState(0);
+
+  // 滚动到顶部（对于客户端路由跳转时仍有用）
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pack.id]); // 依赖 pack.id 确保在从详情页A跳转到详情页B时也会滚动
+
+  // 移除了原始的 useEffect 数据获取逻辑，因为数据现在通过 props 传入
+
+  const handleDownloadClick = () => {
+    const disclaimerAccepted = localStorage.getItem("disclaimerAccepted") === "true";
+
+    if (disclaimerAccepted) {
+      if (pack) window.open(pack.downloadLink, "_blank");
+    } else {
+      setIsDisclaimerOpen(true);
+    }
+  };
+
+  const handleDisclaimerAccept = () => {
+    setIsDisclaimerOpen(false);
+    if (pack) window.open(pack.downloadLink, "_blank");
+  };
+
+  const handleShare = () => {
+    if (navigator.share) {
+      if (pack) {
+        navigator
+          .share({
+            title: pack.title,
+            text: `Check out this Minecraft translation pack: ${pack.title}`,
+            url: window.location.href,
+          })
+          .catch((error) => console.log("Error sharing", error));
+      }
+    } else {
+      navigator.clipboard
+        .writeText(window.location.href)
+        .then(() => {
+          alert("链接已复制至剪贴板!");
+        })
+        .catch((err) => {
+          console.error("Could not copy text: ", err);
+        });
+    }
+  };
+
+  const nextScreenshot = () => {
+    if (pack && pack.screenshots && pack.screenshots.length > 0) {
+      setCurrentScreenshot((prev) => (prev + 1) % pack.screenshots.length);
+    }
+  };
+
+  const prevScreenshot = () => {
+    if (pack && pack.screenshots && pack.screenshots.length > 0) {
+      setCurrentScreenshot((prev) => (prev - 1 + pack.screenshots.length) % pack.screenshots.length);
+    }
+  };
+
+  // 计算星级显示，这部分是纯展示逻辑，可以直接放在渲染中
+  const studio = STUDIOS.find((s) => s.id === pack.studio);
+  const screenshots = pack.screenshots || [];
+
+  return (
+    <div className="min-h-screen pb-20">
+      {/* Hero Section */}
+      <section className="relative py-8 animate-fade-in">
+        <div className="container">
+          <Link href="/market" className="inline-flex items-center text-muted-foreground hover:text-primary mb-4">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            回到市场
+          </Link>
+
+          <div className="grid md:grid-cols-2 gap-8">
+            <div className="minecraft-card overflow-hidden">
+              {pack.isDLC && (
+                <div className="absolute top-4 left-4 z-10">
+                  <span className="bg-yellow-500 text-black font-pixel px-3 py-1">DLC</span>
+                </div>
+              )}
+              <Image
+                src={pack.image || "/placeholder.svg"}
+                alt={pack.title}
+                width={600}
+                height={400}
+                className="w-full h-auto object-cover"
+              />
+            </div>
+
+            <div className="space-y-6">
+              <div>
+                <div className="flex flex-wrap gap-2 mb-2">
+                  {pack.tags.map((tag) => (
+                    <Link href={`/market/tag/${tag.toLowerCase()}`} key={tag}>
+                      <span className="tag-pill">{tag}</span>
+                    </Link>
+                  ))}
+                </div>
+                <h1 className="text-3xl font-pixel">{pack.title}</h1>
+                <p className="text-muted-foreground mt-2">{pack.description}</p>
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div className="minecraft-card p-3">
+                  <div className="flex items-center text-muted-foreground mb-1">
+                    <Star className="h-4 w-4 mr-1" />
+                    <span className="text-sm">评分</span>
+                  </div>
+                  <div className="flex items-center">
+                    <StarRating rate={pack.rating} />
+                    <span className="ml-2 font-pixel text-lg">{pack.rating.toFixed(1)}</span>
+                  </div>
+                </div>
+
+                <div className="minecraft-card p-3">
+                  <div className="flex items-center text-muted-foreground mb-1">
+                    <Calendar className="h-4 w-4 mr-1" />
+                    <span className="text-sm">更新时间</span>
+                  </div>
+                  <p className="font-pixel text-lg">{formatDate(pack.updatedAt)}</p>
+                </div>
+
+                <div className="minecraft-card p-3">
+                  <div className="flex items-center text-muted-foreground mb-1">
+                    <Globe className="h-4 w-4 mr-1" />
+                    <span className="text-sm">翻译语言</span>
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {pack.languages.map((lang) => (
+                      <span key={lang} className="text-xs px-2 py-1 rounded">
+                        {getLanguageDisplayName(lang)}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="minecraft-card p-3">
+                  <div className="flex items-center text-muted-foreground mb-1">
+                    <span className="text-sm">地图价格</span>
+                  </div>
+                  <p className="font-pixel text-lg">{pack.price === 0 ? "免费" : `${pack.price} MC`}</p>
+                </div>
+              </div>
+
+              <div className="flex flex-col sm:flex-row gap-4">
+                <Button className="minecraft-btn flex-1 justify-center" onClick={handleDownloadClick}>
+                  下载翻译包
+                </Button>
+                <Button variant="outline" size="icon" onClick={handleShare}>
+                  <Share2 className="h-5 w-5" />
+                  <span className="sr-only">分享</span>
+                </Button>
+              </div>
+
+              <div className="grid grid-cols-2 gap-x-8 gap-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">翻译作者:</span>
+                  <span>{pack.author}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">地图工作室:</span>
+                  <Link
+                    href={`/market/studio/${pack.studio.toLowerCase().replace(/\s+/g, "-")}`}
+                    className="hover:text-primary"
+                  >
+                    {studio ? studio.name : "无名氏"}
+                  </Link>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">发布时间:</span>
+                  <span>{formatDate(pack.createdAt)}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+          </div>
+        </section>
+
+      {/* Content Tabs */}
+      <section className="py-8 animate-fade-in animate-delay-100">
+        <div className="container">
+          <Tabs defaultValue="details">
+            <TabsList className="grid w-full grid-cols-3 mb-2">
+              <TabsTrigger value="details" className="font-pixel text-xs sm:text-sm">
+                详情
+              </TabsTrigger>
+              <TabsTrigger value="screenshots" className="font-pixel text-xs sm:text-sm">
+                截图
+              </TabsTrigger>
+              <TabsTrigger value="installation" className="font-pixel text-xs sm:text-sm">
+                安装
+              </TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="details" className="mt-6">
+              <div className="minecraft-card p-6">
+                <h2 className="text-xl font-pixel mb-4">包含内容</h2>
+                <p>{pack.description}</p>
+                <ul className="space-y-2">
+                  {pack.features.map((feature, index) => (
+                    <li key={index} className="flex items-start">
+                      <span className="text-primary mr-2">•</span>
+                      <span>{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <h2 className="text-xl font-pixel mt-8 mb-4">简介</h2>
+                <div className="space-y-4">
+                  <p>
+                    该汉化包是市场包地图 {pack.title} 的翻译资源包，使用本资源包即可使用中文游玩地图。
+                  </p>
+                  <p>
+                    翻译作者对游戏的各个方面进行了精心翻译，确保保留原意和细微差别，同时使其自然流畅地翻译成中文。我们特别关注游戏特定的术语，并始终保持一致性。如有发现任何翻译错误或不规范，欢迎通过 Fanconma@gmail.com 或其他方式提出。
+                  </p>
+                </div>
+
+                <h2 className="text-xl font-pixel mt-8 mb-4">翻译语言</h2>
+                <div className="space-y-2">
+                  {pack.languages.map((lang) => (
+                    <div key={lang} className="flex items-center">
+                      <span className="text-primary mr-2">•</span>
+                      <span>{getLanguageDisplayName(lang)}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </TabsContent>
+
+            <TabsContent value="screenshots" className="mt-6">
+              <div className="minecraft-card p-6">
+                <h2 className="text-xl font-pixel mb-4">截图</h2>
+                
+                {screenshots.length > 0 ? (
+                  <div className="space-y-6">
+                    {/* 主要截图展示 */}
+                    <div className="relative minecraft-card overflow-hidden">
+                      <div className="aspect-video relative">
+                        <Image
+                          src={screenshots[currentScreenshot] || `/placeholder.svg?height=400&width=600&text=${pack.title} Screenshot`}
+                          alt={`Screenshot ${currentScreenshot + 1}`}
+                          fill
+                          className="object-cover"
+                        />
+                      </div>
+                      
+                      {/* 导航按钮 */}
+                      {screenshots.length > 1 && (
+                        <>
+                          <Button 
+                            variant="outline" 
+                            size="icon" 
+                            className="absolute left-2 top-1/2 -translate-y-1/2 z-10 bg-background/80 backdrop-blur-sm rounded-full"
+                            onClick={prevScreenshot}
+                          >
+                            <ChevronLeft className="h-4 w-4" />
+                            <span className="sr-only">前一张截图</span>
+                          </Button>
+                          
+                          <Button 
+                            variant="outline" 
+                            size="icon" 
+                            className="absolute right-2 top-1/2 -translate-y-1/2 z-10 bg-background/80 backdrop-blur-sm rounded-full"
+                            onClick={nextScreenshot}
+                          >
+                            <ChevronRight className="h-4 w-4" />
+                            <span className="sr-only">下一张截图</span>
+                          </Button>
+                        </>
+                      )}
+                      
+                      {/* 截图计数器 */}
+                      <div className="absolute bottom-2 right-2 bg-background/80 backdrop-blur-sm px-2 py-1 rounded text-xs">
+                        {currentScreenshot + 1} / {screenshots.length}
+                      </div>
+                    </div>
+                    
+                    {/* 缩略图导航 */}
+                    {screenshots.length > 1 && (
+                      <div className="grid grid-cols-4 sm:grid-cols-6 gap-2">
+                        {screenshots.map((screenshot, index) => (
+                          <button
+                            key={index}
+                            title="继续"
+                            className={`minecraft-card overflow-hidden ${index === currentScreenshot ? 'ring-2 ring-primary' : ''}`}
+                            onClick={() => setCurrentScreenshot(index)}
+                          >
+                            <div className="aspect-video relative">
+                              <Image
+                                src={screenshot || `/placeholder.svg?height=100&width=150&text=Thumb ${index + 1}`}
+                                alt={`Thumbnail ${index + 1}`}
+                                fill
+                                className="object-cover"
+                              />
+                            </div>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    {[1, 2, 3].map((index) => (
+                      <div key={index} className="minecraft-card overflow-hidden">
+                        <Image
+                          src={`/placeholder.svg?height=400&width=600&text=${pack.title} Screenshot ${index}`}
+                          alt={`Screenshot ${index}`}
+                          width={600}
+                          height={400}
+                          className="w-full h-auto object-cover"
+                        />
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </TabsContent>
+
+            <TabsContent value="installation" className="mt-6">
+              <div className="minecraft-card p-6">
+                <h2 className="text-xl font-pixel mb-4">翻译包安装说明</h2>
+                <ol className="space-y-4">
+                  {[
+                    "下载.mcpack后缀的资源包文件",
+                    "选择\"使用 Minecraft 打开\"该紫云阿宝文件",
+                    "进入对应市场地图的创建页面",
+                    '点击蓝色背景的\"解锁设置\"',
+                    "进入资源包页面并激活对应的汉化资源包",
+                  ].map((step, index) => (
+                    <li key={index} className="flex items-start">
+                      <span className="font-pixel text-primary mr-2">{index + 1}.</span>
+                      <span>{step}</span>
+                    </li>
+                  ))}
+                </ol>
+
+                <div className="mt-8 p-4 bg-muted/50 rounded-md">
+                  <h3 className="font-pixel text-lg mb-2">故障排除</h3>
+                  <p className="mb-4">如果您在使用翻译包时遇到任何问题，请尝试以下操作：</p>
+                  <ul className="space-y-2">
+                  <li className="flex items-start">
+                      <span className="text-primary mr-2">•</span>
+                      <h2>蓝奏云下载时要点开汉化包文件才可直接下载</h2>
+                    </li>
+                    <li className="flex items-start">
+                      <span className="text-primary mr-2">•</span>
+                      <span>确保你使用的 Minecraft 版本兼容地图</span>
+                    </li>
+                    <li className="flex items-start">
+                      <span className="text-primary mr-2">•</span>
+                      <span>确保你的语言是汉化包所对应的语言而不是其他语言（例如汉化包不支持繁体中文而你正在使用繁体中文）</span>
+                    </li>
+                    <li className="flex items-start">
+                      <span className="text-primary mr-2">•</span>
+                      <span>尝试将汉化资源包放于所有资源包的顶端</span>
+                    </li>
+                    <li className="flex items-start">
+                      <span className="text-primary mr-2">•</span>
+                      <span>
+                        浏览我们的{" "}
+                        <Link href="/troubleshooting" className="text-primary hover:underline">
+                          故障排除界面
+                        </Link>{" "}
+                        获取更多帮助
+                      </span>
+                    </li>
+                  </ul>
+                </div>
+
+                <div className="mt-8">
+                  <Button className="minecraft-btn w-full justify-center" onClick={handleDownloadClick}>
+                    下载翻译包
+                  </Button>
+                </div>
+              </div>
+            </TabsContent>
+          </Tabs>
+        </div>
+      </section>
+
+      {/* More from this Studio */}
+      {studioPacks.length > 0 && (
+        <section className="py-8 animate-fade-in animate-delay-200">
+          <div className="container">
+            <h2 className="text-2xl font-pixel mb-6">更多来自 {studio ? studio.name : "无名氏"} 的地图翻译包</h2>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+              {studioPacks.map((studioPack) => (
+                <TranslationPackCard key={studioPack.id} pack={studioPack} />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Similar Translations */}
+      {similarPacks.length > 0 && (
+        <section className="py-8 animate-fade-in animate-delay-300">
+          <div className="container">
+            <h2 className="text-2xl font-pixel mb-6">类似地图的汉化包</h2>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+              {similarPacks.map((similarPack) => (
+                <TranslationPackCard key={similarPack.id} pack={similarPack} />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Disclaimer Popup */}
+      <DisclaimerPopup
+        isOpen={isDisclaimerOpen}
+        onClose={() => setIsDisclaimerOpen(false)}
+        onAccept={handleDisclaimerAccept}
+        packTitle={pack.title}
+      />
+
+      {/* Back to Top Button */}
+      <BackToTop />
+    </div>
+); 
+}

--- a/app/market/market-client.tsx
+++ b/app/market/market-client.tsx
@@ -1,0 +1,403 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import dynamic from "next/dynamic";
+import { useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import SearchBar from "@/components/search-bar";
+import BackToTop from "@/components/back-to-top";
+import { throttle, debounce } from "@/lib/performance";
+import useEmblaCarousel from "embla-carousel-react"; 
+import Autoplay from "embla-carousel-autoplay";
+import { Filter, DoorOpen } from "lucide-react";
+
+// Dynamically import heavy components (keep these in the client component)
+const TranslationPackCard = dynamic(() => import("@/components/translation-pack-card"), {
+  ssr: false,
+  loading: () => <div className="minecraft-card animate-pulse h-64"></div>,
+});
+
+const TagCard = dynamic(() => import("@/components/tag-card"), {
+  ssr: false,
+  loading: () => <div className="minecraft-card animate-pulse h-12"></div>,
+});
+
+const StudioCard = dynamic(() => import("@/components/studio-card"), {
+  ssr: false,
+  loading: () => <div className="minecraft-card animate-pulse h-24"></div>,
+});
+
+const HorizontalScrollSection = dynamic(() => import("@/components/horizontal-scroll-section"), {
+  ssr: false,
+});
+
+// 导入数据源中的类型和常量，以及 getPacksBySectionId 函数
+import {
+  ALL_PACKS,
+  FEATURED_PACKS,
+  TAGS,
+  STUDIOS,
+  SECTIONS,
+  TranslationPack,
+  Studio,
+  Section,
+  getPacksBySectionId, // 👈 新增导入
+} from "@/data/translation-packs";
+
+// Helper function for date formatting (from previous steps)
+const formatDateString = (dateString: string | undefined | null) => {
+  if (!dateString) {
+    return "N/A";
+  }
+  const formattedDateString = dateString.replace(/(\d{4})(\d{2})(\d{2})/, '$1-$2-$3');
+  const date = new Date(formattedDateString);
+  if (isNaN(date.getTime())) {
+    return "无效日期格式";
+  }
+  return date;
+};
+
+
+interface MarketClientProps {
+  initialFilteredPacks: TranslationPack[];
+  initialSelectedTag: string | null;
+  initialSearchQuery: string;
+  initialIsSearching: boolean;
+  recentPacks: TranslationPack[];
+  featuredPacks: TranslationPack[];
+  tags: string[];
+  studios: Studio[];
+  sections: Section[];
+}
+
+export default function MarketClient({
+  initialFilteredPacks,
+  initialSelectedTag,
+  initialSearchQuery,
+  initialIsSearching,
+  recentPacks,
+  featuredPacks,
+  tags,
+  studios,
+  sections,
+}: MarketClientProps) {
+  const searchParams = useSearchParams();
+  const currentSelectedTagFromUrl = searchParams.get("tag");
+
+  const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
+  const [selectedTag, setSelectedTag] = useState(initialSelectedTag);
+  const INITIAL_VISIBLE_PACKS = useMemo(() => {
+    return typeof window !== "undefined" && window.innerWidth < 768 ? 6 : 12;
+  }, []);
+  const [visiblePacks, setVisiblePacks] = useState(INITIAL_VISIBLE_PACKS);
+  const [isSearching, setIsSearching] = useState(initialIsSearching);
+  const packListRef = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLDivElement>(null);
+
+  const [emblaRef] = useEmblaCarousel(
+    {
+      loop: true,
+      align: "start",
+      skipSnaps: false,
+      dragFree: true,
+    },
+    [Autoplay({ delay: 5000, stopOnInteraction: false })],
+  );
+
+  useEffect(() => {
+    setSelectedTag(currentSelectedTagFromUrl);
+  }, [currentSelectedTagFromUrl]);
+
+  const filteredPacks = useMemo(() => {
+    let currentPacks = ALL_PACKS;
+
+    if (selectedTag) {
+      currentPacks = currentPacks.filter((pack) => pack.tags.some((tag) => tag.toLowerCase() === selectedTag.toLowerCase()));
+    }
+
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      currentPacks = currentPacks.filter(
+        (pack) =>
+          pack.title.toLowerCase().includes(query) ||
+          pack.description.toLowerCase().includes(query) ||
+          pack.tags.some((tag) => tag.toLowerCase().includes(query)) ||
+          pack.author.toLowerCase().includes(query) ||
+          pack.studio.toLowerCase().includes(query),
+      );
+    }
+    return currentPacks;
+  }, [selectedTag, searchQuery]);
+
+  useEffect(() => {
+    setIsSearching(!!searchQuery);
+    setVisiblePacks(INITIAL_VISIBLE_PACKS);
+  }, [searchQuery, selectedTag, INITIAL_VISIBLE_PACKS]);
+
+  const handleScroll = useCallback(
+    throttle(() => {
+      if (!packListRef.current) return;
+
+      const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
+      if (scrollTop + clientHeight >= scrollHeight - 300 && visiblePacks < filteredPacks.length) {
+        setVisiblePacks((prev) => Math.min(prev + 6, filteredPacks.length));
+      }
+    }, 500),
+    [filteredPacks, visiblePacks],
+  );
+
+  useEffect(() => {
+    window.addEventListener("scroll", handleScroll);
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [handleScroll]);
+
+  const handleSearch = useCallback(
+    debounce((query: string) => {
+      setSearchQuery(query);
+    }, 300),
+    [],
+  );
+
+  const scrollToSearch = () => {
+    if (searchInputRef.current) {
+      searchInputRef.current.scrollIntoView({ behavior: "smooth" });
+      const inputElement = searchInputRef.current.querySelector("input");
+      if (inputElement) {
+        inputElement.focus();
+      }
+    }
+  };
+
+  return (
+    <div className="min-h-screen pb-20">
+      {/* Hero Section */}
+      <section className="relative py-12 md:py-20 overflow-hidden">
+        <div className="absolute inset-0 z-0">
+          <Image
+            src="/images/market.jpeg"
+            alt="Minecraft marketplace"
+            fill
+            className="object-cover opacity-20"
+            priority
+          />
+        </div>
+        <div className="container relative z-10">
+          <div className="max-w-3xl mx-auto text-center space-y-6">
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-pixel tracking-tight animate-fade-in">
+              MARKETPLACE<br /> <span className="text-primary">TRANSLATION</span>
+            </h1>
+            <p className="text-lg text-muted-foreground animate-fade-in animate-delay-100">
+              浏览我们精选的 Minecraft 英译中翻译包。所有翻译包均可免费下载。
+            </p>
+
+            {/* Search Bar */}
+            <div ref={searchInputRef} className="max-w-md mx-auto mt-6 animate-fade-in animate-delay-200">
+              <SearchBar onSearch={handleSearch} initialQuery={initialSearchQuery}/>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Featured Carousel - Only show when not searching */}
+      {!isSearching && (
+        <section className="py-12 bg-gray-900/50 animate-fade-in animate-delay-300">
+          <div className="container">
+            <h2 className="text-2xl font-pixel mb-6">推荐汉化包</h2>
+
+            <div className="overflow-hidden" ref={emblaRef}>
+              <div className="flex">
+                {featuredPacks.map((pack) => {
+                  if (pack.isFeatured) {
+                    const studio = STUDIOS.find((studio) => studio.id === pack.studio);
+                    return (
+                      <div key={pack.id} className="flex-[0_0_100%] min-w-0 pl-4 md:flex-[0_0_50%] lg:flex-[0_0_50%]">
+                        <Link href={`/market/${pack.id}`} className="block">
+                          <div className="relative aspect-video overflow-hidden rounded-lg group">
+                            <Image
+                              src={pack.image || "/placeholder.svg"}
+                              alt={pack.title}
+                              fill
+                              className="object-cover transition-transform duration-500 group-hover:scale-105"
+                            />
+                            <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent"></div>
+
+                            <div className="absolute bottom-0 left-0 p-6">
+                              <h3 className="font-pixel text-xl text-white mb-2">{pack.title}</h3>
+                              <p className="text-sm text-gray-300 line-clamp-2">{pack.description}</p>
+                              <div className="flex items-center mt-2">
+                                <span className="text-xs text-gray-400 mr-4">{studio ? studio.name : "无名氏"}</span>
+                                <span className="text-xs text-primary flex items-center">
+                                  <span className="mr-1">价格:</span>
+                                  {pack.price === 0 ? "免费" : `${pack.price} MC`}
+                                </span>
+                              </div>
+                            </div>
+
+                            {/* New/Updated Tag - using formatDateString helper */}
+                            {(() => {
+                              const currentDate = new Date();
+                              const createdDate = formatDateString(pack.createdAt);
+                              const updatedDate = formatDateString(pack.updatedAt);
+
+                              const isNew = createdDate && (currentDate.getTime() - createdDate.getTime()) / (1000 * 3600 * 24) <= 7;
+                              const isUpdated = !isNew && updatedDate && (currentDate.getTime() - updatedDate.getTime()) / (1000 * 3600 * 24) <= 7;
+
+                              if (isNew) {
+                                return (
+                                  <div className="absolute top-4 right-4">
+                                    <span className="tag-pill">New</span>
+                                  </div>
+                                );
+                              } else if (isUpdated) {
+                                return (
+                                  <div className="absolute top-4 right-4">
+                                    <span className="tag-pill bg-blue-600">Updated</span>
+                                  </div>
+                                );
+                              }
+                              return null;
+                            })()}
+
+                            {pack.isDLC && (
+                              <div className="absolute top-4 left-4">
+                                <span className="bg-yellow-500 text-black font-pixel px-3 py-1">DLC</span>
+                              </div>
+                            )}
+                          </div>
+                        </Link>
+                      </div>
+                    );
+                  }
+                  return null;
+                })}
+              </div>
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Tags Section - Only show when not searching */}
+      {!isSearching && (
+        <section className="py-8 animate-fade-in animate-delay-400">
+          <div className="container">
+            <div className="flex items-center mb-4">
+              <Filter className="h-5 w-5 mr-2" />
+              <h2 className="text-xl font-pixel">按标签浏览</h2>
+            </div>
+
+            <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-3">
+              {tags.map((tag) => (
+                <TagCard key={tag} tag={tag} isSelected={selectedTag?.toLowerCase() === tag.toLowerCase()} />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Studios Section - Only show when not searching */}
+      {!isSearching && (
+        <section className="py-8 animate-fade-in animate-delay-500">
+          <div className="container">
+            <div className="flex items-center mb-4">
+              <DoorOpen className="h-5 w-5 mr-2" />
+              <h2 className="text-xl font-pixel">按工作室浏览</h2>
+            </div>
+
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+              {studios.map((studio) => (
+                <StudioCard key={studio.id} studio={studio} />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* Dynamic Sections based on data - Only show when not searching */}
+      {!isSearching &&
+        sections.map((section) => {
+          // 修正：使用 getPacksBySectionId 函数来获取该 section 的包
+          const sectionPacks = getPacksBySectionId(section.id);
+
+          if (sectionPacks.length === 0) return null;
+
+          return (
+            <section key={section.id} className="py-8 animate-fade-in animate-delay-600">
+              <div className="container">
+                <HorizontalScrollSection
+                  title={section.title}
+                  description={section.description}
+                  viewAllHref={`/market/section/${section.id}`}
+                >
+                  {sectionPacks.slice(0, 10).map((pack) => (
+                    <div key={pack.id} className="w-80">
+                      <TranslationPackCard pack={pack} size="large" />
+                    </div>
+                  ))}
+                </HorizontalScrollSection>
+              </div>
+            </section>
+          );
+        })}
+
+      {/* Recent Translations Section - Only show when not searching */}
+      {!isSearching && (
+        <section className="py-8 animate-fade-in animate-delay-700">
+          <div className="container">
+            <div className="flex justify-between items-center mb-8">
+              <h2 className="text-2xl font-pixel">最新翻译</h2>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {recentPacks.map((pack) => (
+                <TranslationPackCard key={pack.id} pack={pack} />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {/* All Translation Packs or Search Results */}
+      <section className="py-8 animate-fade-in animate-delay-800">
+        <div className="container">
+          <h2 className="text-2xl font-pixel mb-6">
+            {isSearching ? `"${searchQuery}" 的搜索结果` : "全部翻译包"}
+          </h2>
+
+          <div ref={packListRef} className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+            {filteredPacks.slice(0, visiblePacks).map((pack) => (
+              <TranslationPackCard key={pack.id} pack={pack} />
+            ))}
+          </div>
+
+          {visiblePacks < filteredPacks.length && (
+            <div className="mt-8 text-center">
+              <Button
+                onClick={() => setVisiblePacks((prev) => Math.min(prev + 6, filteredPacks.length))}
+                className="minecraft-btn"
+              >
+                加载更多
+              </Button>
+            </div>
+          )}
+
+          {filteredPacks.length === 0 && (
+            <div className="text-center py-12">
+              <h3 className="text-xl font-pixel mb-2">未找到翻译包</h3>
+              <p className="text-muted-foreground">尝试调整您的过滤条件或搜索词</p>
+              <Button asChild className="minecraft-btn mt-4">
+                <Link href="/market">清除筛选器</Link>
+              </Button>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Back to Top Button */}
+      <BackToTop />
+    </div>
+  );
+}

--- a/app/market/page.tsx
+++ b/app/market/page.tsx
@@ -191,9 +191,9 @@ export default function MarketPage() {
           name="keywords"
           content="Minecraft中文翻译, 基岩版翻译包, 免费Minecraft资源, 游戏中文本地化, Minecraft资源市场"
         />
-        <meta name="og:title" content={pageTitle} />
-        <meta name="og:description" content="浏览PixelLingual的Minecraft中文翻译市场。免费下载高质量的游戏内容翻译，提升您的游戏体验。" />
-        <meta name="og:url" content="https://pling.top/market" />
+        <meta property="og:title" content={pageTitle} />
+        <meta property="og:description" content="浏览PixelLingual的Minecraft中文翻译市场。免费下载高质量的游戏内容翻译，提升您的游戏体验。" />
+        <meta property="og:url" content="https://pling.top/market" />
       </Head>
     <div className="min-h-screen pb-20">
       {/* Hero Section */}

--- a/app/market/page.tsx
+++ b/app/market/page.tsx
@@ -191,9 +191,9 @@ export default function MarketPage() {
           name="keywords"
           content="Minecraft中文翻译, 基岩版翻译包, 免费Minecraft资源, 游戏中文本地化, Minecraft资源市场"
         />
-        <meta property="og:title" content={pageTitle} />
-        <meta property="og:description" content="浏览PixelLingual的Minecraft中文翻译市场。免费下载高质量的游戏内容翻译，提升您的游戏体验。" />
-        <meta property="og:url" content="https://pling.top/market" />
+        <meta name="og:title" content={pageTitle} />
+        <meta name="og:description" content="浏览PixelLingual的Minecraft中文翻译市场。免费下载高质量的游戏内容翻译，提升您的游戏体验。" />
+        <meta name="og:url" content="https://pling.top/market" />
       </Head>
     <div className="min-h-screen pb-20">
       {/* Hero Section */}

--- a/app/market/page.tsx
+++ b/app/market/page.tsx
@@ -1,436 +1,136 @@
-"use client"
-
-import { useState, useEffect, useRef, useCallback, useMemo } from "react"
-import Image from "next/image"
-import Link from "next/link"
-import dynamic from "next/dynamic"
-import Head from "next/head"
-import { useSearchParams } from "next/navigation"
-import { Button } from "@/components/ui/button"
-import SearchBar from "@/components/search-bar"
-import BackToTop from "@/components/back-to-top"
-import { throttle, debounce } from "@/lib/performance"
-import useEmblaCarousel from "embla-carousel-react"
-import Autoplay from "embla-carousel-autoplay"
-import { Filter, DoorOpen } from "lucide-react"
-
-// Dynamically import heavy components
-/**
- * Dynamically loads the `TranslationPackCard` component with client-side rendering only (SSR disabled).
- * While loading, displays a placeholder div styled as a Minecraft card with a pulsing animation.
- *
- * @remarks
- * This dynamic import is useful for components that rely on browser-specific APIs or should not be rendered on the server.
- *
- * @see {@link https://nextjs.org/docs/pages/building-your-application/optimizing/dynamic-imports}
- */
-const TranslationPackCard = dynamic(() => import("@/components/translation-pack-card"), {
-  ssr: false,
-  loading: () => <div className="minecraft-card animate-pulse h-64"></div>,
-})
-
-const TagCard = dynamic(() => import("@/components/tag-card"), {
-  ssr: false,
-  loading: () => <div className="minecraft-card animate-pulse h-12"></div>,
-})
-
-const StudioCard = dynamic(() => import("@/components/studio-card"), {
-  ssr: false,
-  loading: () => <div className="minecraft-card animate-pulse h-24"></div>,
-})
-
-const HorizontalScrollSection = dynamic(() => import("@/components/horizontal-scroll-section"), {
-  ssr: false,
-})
-
+import { Metadata } from 'next';
+// 移除所有客户端相关的导入和逻辑
 import {
   ALL_PACKS,
   FEATURED_PACKS,
   TAGS,
   STUDIOS,
   SECTIONS,
-  getPacksBySectionId,
   getMostRecentPacks,
-} from "@/data/translation-packs"
+  // getPacksBySectionId, // 暂时不需要在这里获取，可以在客户端组件中自行过滤
+} from "@/data/translation-packs";
+import MarketClient from "./market-client"; // 导入客户端组件
 
-export default function MarketPage() {
-  const searchParams = useSearchParams()
-  const selectedTag = searchParams.get("tag")
-  const [searchQuery, setSearchQuery] = useState("")
-  const [pageTitle, setPageTitle] = useState("翻译包市场 | PixelLingual像素语匠")
-  const INITIAL_VISIBLE_PACKS = useMemo(() => {
-    return typeof window !== "undefined" && window.innerWidth < 768 ? 6 : 12;
-  }, []);
-  const [visiblePacks, setVisiblePacks] = useState(INITIAL_VISIBLE_PACKS) // Initial number of packs to show
-  const filteredPacks = useMemo(() => {
-    let filtered = ALL_PACKS;
-
-    // Apply tag filter if selected
-    if (selectedTag) {
-      filtered = filtered.filter((pack) => pack.tags.some((tag) => tag.toLowerCase() === selectedTag.toLowerCase()));
-    }
-
-    // Apply search filter if query exists
-    if (searchQuery) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter(
-        (pack) =>
-          pack.title.toLowerCase().includes(query) ||
-          pack.description.toLowerCase().includes(query) ||
-          pack.tags.some((tag) => tag.toLowerCase().includes(query)) ||
-          pack.author.toLowerCase().includes(query) ||
-          pack.studio.toLowerCase().includes(query),
-      );
-    }
-
-    return filtered;
-  }, [ALL_PACKS, selectedTag, searchQuery]);
-  const [isSearching, setIsSearching] = useState(false)
-  const packListRef = useRef<HTMLDivElement>(null)
-  const searchInputRef = useRef<HTMLDivElement>(null)
-  const recentPacks = getMostRecentPacks(3)
-
-  // Setup autoplay carousel with improved options
-  const [emblaRef] = useEmblaCarousel(
-    {
-      loop: true,
-      align: "start",
-      skipSnaps: false,
-      dragFree: true,
-    },
-    [Autoplay({ delay: 5000, stopOnInteraction: false })],
-  )
-
-  // 动态设置页面标题
-  useEffect(() => {
-    let title = "翻译市场 - PixelLingual"
-
-    if (selectedTag) {
-      const formattedTag = selectedTag.charAt(0).toUpperCase() + selectedTag.slice(1)
-      title = `${formattedTag} 翻译 - PixelLingual`
-    } else if (searchQuery) {
-      title = `搜索 "${searchQuery}" - PixelLingual`
-    }
-
-    setPageTitle(title)
-    document.title = title
-  }, [selectedTag, searchQuery])
-  
-  // Filter packs based on selected tag and search query
-  useEffect(() => {
-    let filtered = ALL_PACKS
-
-    // Apply tag filter if selected
-    if (selectedTag) {
-      filtered = filtered.filter((pack) => pack.tags.some((tag) => tag.toLowerCase() === selectedTag.toLowerCase()))
-    }
-
-    // Apply search filter if query exists
-    if (searchQuery) {
-      const query = searchQuery.toLowerCase()
-      filtered = filtered.filter(
-        (pack) =>
-          pack.title.toLowerCase().includes(query) ||
-          pack.description.toLowerCase().includes(query) ||
-          pack.tags.some((tag) => tag.toLowerCase().includes(query)) ||
-          pack.author.toLowerCase().includes(query) ||
-          pack.studio.toLowerCase().includes(query),
-      )
-      setIsSearching(true)
-    } else {
-      setIsSearching(false)
-    }
-
-    // No need to set state for filteredPacks as it's now memoized
-    setVisiblePacks(12) // Reset visible packs when filter changes
-  }, [selectedTag, searchQuery])
-
-  // Handle infinite scroll
-  const handleScroll = useCallback(
-    throttle(() => {
-    if (!packListRef.current) return
-
-    const { scrollTop, scrollHeight, clientHeight } = document.documentElement
-    if (scrollTop + clientHeight >= scrollHeight - 300 && visiblePacks < filteredPacks.length) {
-      setVisiblePacks((prev) => Math.min(prev + 6, filteredPacks.length))
-    }
-  },500), [filteredPacks, visiblePacks],)
-
-  useEffect(() => {
-    window.addEventListener("scroll", handleScroll)
-    return () => window.removeEventListener("scroll", handleScroll)
-  }, [filteredPacks, visiblePacks, handleScroll])
-
-  // Handle search
-  const handleSearch = useCallback(
-    debounce((query: string) => {
-    setSearchQuery(query)
-  },300),[],)
-
-  // Scroll to search input
-  const scrollToSearch = () => {
-    if (searchInputRef.current) {
-      searchInputRef.current.scrollIntoView({ behavior: "smooth" })
-      // Focus the input after scrolling
-      const inputElement = searchInputRef.current.querySelector("input")
-      if (inputElement) {
-        inputElement.focus()
-      }
-    }
-  }
-
-  return (
-    <>
-      <Head>
-        <title>{pageTitle}</title>
-        <meta
-          name="description"
-          content="浏览PixelLingual的Minecraft中文翻译市场。免费下载高质量的游戏内容翻译，提升您的游戏体验。"
-        />
-        <meta
-          name="keywords"
-          content="Minecraft中文翻译, 基岩版翻译包, 免费Minecraft资源, 游戏中文本地化, Minecraft资源市场"
-        />
-        <meta property="og:title" content={pageTitle} />
-        <meta property="og:description" content="浏览PixelLingual的Minecraft中文翻译市场。免费下载高质量的游戏内容翻译，提升您的游戏体验。" />
-        <meta property="og:url" content="https://pling.top/market" />
-      </Head>
-    <div className="min-h-screen pb-20">
-      {/* Hero Section */}
-      <section className="relative py-12 md:py-20 overflow-hidden">
-        <div className="absolute inset-0 z-0">
-          <Image
-            src="/images/market.jpeg"
-            alt="Minecraft marketplace"
-            fill
-            className="object-cover opacity-20"
-            priority
-          />
-        </div>
-        <div className="container relative z-10">
-
-          <div className="max-w-3xl mx-auto text-center space-y-6">
-            <h1 className="text-3xl md:text-4xl lg:text-5xl font-pixel tracking-tight animate-fade-in">
-            MARKETPLACE<br/> <span className="text-primary">TRANSLATION</span>
-            </h1>
-            <p className="text-lg text-muted-foreground animate-fade-in animate-delay-100">
-              浏览我们精选的 Minecraft 英译中翻译包。所有翻译包均可免费下载。
-            </p>
-
-            {/* Search Bar */}
-            <div ref={searchInputRef} className="max-w-md mx-auto mt-6 animate-fade-in animate-delay-200">
-              <SearchBar onSearch={handleSearch} />
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Featured Carousel - Only show when not searching */}
-      {!isSearching && (
-        <section className="py-12 bg-gray-900/50 animate-fade-in animate-delay-300">
-          <div className="container">
-            <h2 className="text-2xl font-pixel mb-6">推荐汉化包</h2>
-
-            <div className="overflow-hidden" ref={emblaRef}>
-              <div className="flex">
-                {FEATURED_PACKS.map((pack) => { if (pack.isFeatured){
-                  const studio = STUDIOS.find((studio) => studio.id === pack.studio);
-                  return(
-                  <div key={pack.id} className="flex-[0_0_100%] min-w-0 pl-4 md:flex-[0_0_50%] lg:flex-[0_0_50%]">
-                    <Link href={`/market/${pack.id}`} className="block">
-                      <div className="relative aspect-video overflow-hidden rounded-lg group">
-                        <Image
-                          src={pack.image || "/placeholder.svg"}
-                          alt={pack.title}
-                          fill
-                          className="object-cover transition-transform duration-500 group-hover:scale-105"
-                        />
-                        <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent"></div>
-
-                        <div className="absolute bottom-0 left-0 p-6">
-                          <h3 className="font-pixel text-xl text-white mb-2">{pack.title}</h3>
-                          <p className="text-sm text-gray-300 line-clamp-2">{pack.description}</p>
-                          <div className="flex items-center mt-2">
-                            <span className="text-xs text-gray-400 mr-4">{studio? studio.name:"无名氏"}</span>
-                            <span className="text-xs text-primary flex items-center">
-                              <span className="mr-1">价格:</span>
-                              {pack.price === 0 ? "免费" : `${pack.price} MC`}
-                            </span>
-                          </div>
-                        </div>
-
-                        {/* New/Updated Tag */}
-                        {(() => {
-                          const currentDate = new Date()
-                          const createdDate = new Date(
-                            Number.parseInt(pack.createdAt.substring(0, 4)),
-                            Number.parseInt(pack.createdAt.substring(4, 6)) - 1,
-                            Number.parseInt(pack.createdAt.substring(6, 8)),
-                          )
-
-                          const updatedDate = new Date(
-                            Number.parseInt(pack.updatedAt.substring(0, 4)),
-                            Number.parseInt(pack.updatedAt.substring(4, 6)) - 1,
-                            Number.parseInt(pack.updatedAt.substring(6, 8)),
-                          )
-
-                          const isNew = (currentDate.getTime() - createdDate.getTime()) / (1000 * 3600 * 24) <= 7
-                          const isUpdated =
-                            !isNew && (currentDate.getTime() - updatedDate.getTime()) / (1000 * 3600 * 24) <= 7
-
-                          if (isNew) {
-                            return (
-                              <div className="absolute top-4 right-4">
-                                <span className="tag-pill">New</span>
-                              </div>
-                            )
-                          } else if (isUpdated) {
-                            return (
-                              <div className="absolute top-4 right-4">
-                                <span className="tag-pill bg-blue-600">Updated</span>
-                              </div>
-                            )
-                          }
-
-                          return null
-                        })()}
-
-                        {pack.isDLC && (
-                          <div className="absolute top-4 left-4">
-                            <span className="bg-yellow-500 text-black font-pixel px-3 py-1">DLC</span>
-                          </div>
-                        )}
-                      </div>
-                    </Link>
-                  </div>
-                )}})}
-              </div>
-            </div>
-          </div>
-        </section>
-      )}
-
-      {/* Tags Section - Only show when not searching */}
-      {!isSearching && (
-        <section className="py-8 animate-fade-in animate-delay-400">
-          <div className="container">
-            <div className="flex items-center mb-4">
-              <Filter className="h-5 w-5 mr-2" />
-              <h2 className="text-xl font-pixel">按标签浏览</h2>
-            </div>
-
-            <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-3">
-              {TAGS.map((tag) => (
-                <TagCard key={tag} tag={tag} isSelected={selectedTag?.toLowerCase() === tag.toLowerCase()} />
-              ))}
-            </div>
-          </div>
-        </section>
-      )}
-
-      {/* Studios Section - Only show when not searching */}
-      {!isSearching && (
-        <section className="py-8 animate-fade-in animate-delay-500">
-          <div className="container">
-            <div className="flex items-center mb-4">
-              <DoorOpen className="h-5 w-5 mr-2" />
-              <h2 className="text-xl font-pixel">按工作室浏览</h2>
-            </div>
-
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-              {STUDIOS.map((studio) => (
-                <StudioCard key={studio.id} studio={studio} />
-              ))}
-            </div>
-          </div>
-        </section>
-      )}
-
-      {/* Dynamic Sections based on data - Only show when not searching */}
-      {!isSearching &&
-        SECTIONS.map((section) => {
-          const sectionPacks = getPacksBySectionId(section.id)
-
-          if (sectionPacks.length === 0) return null
-
-          return (
-            <section key={section.id} className="py-8 animate-fade-in animate-delay-600">
-              <div className="container">
-                <HorizontalScrollSection
-                  title={section.title}
-                  description={section.description}
-                  viewAllHref={`/market/section/${section.id}`}
-                >
-                  {sectionPacks.slice(0, 10).map((pack) => (
-                    <div key={pack.id} className="w-80">
-                      <TranslationPackCard pack={pack} size="large" />
-                    </div>
-                  ))}
-                </HorizontalScrollSection>
-              </div>
-            </section>
-          )
-        })}
-
-      {/* Recent Translations Section - Only show when not searching */}
-      {!isSearching && (
-        <section className="py-8 animate-fade-in animate-delay-700">
-          <div className="container">
-            <div className="flex justify-between items-center mb-8">
-              <h2 className="text-2xl font-pixel">最新翻译</h2>
-              {/* <Button asChild variant="link" className="font-pixel">
-                <Link href="/market">View All</Link>
-              </Button> */}
-            </div>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-              {recentPacks.map((pack) => (
-                <TranslationPackCard key={pack.id} pack={pack} />
-              ))}
-            </div>
-          </div>
-        </section>
-      )}
-
-      {/* All Translation Packs or Search Results */}
-      <section className="py-8 animate-fade-in animate-delay-800">
-        <div className="container">
-          <h2 className="text-2xl font-pixel mb-6">
-            {isSearching ? `"${searchQuery}" 的搜索结果` : "全部翻译包"}
-          </h2>
-
-          <div ref={packListRef} className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-            {filteredPacks.slice(0, visiblePacks).map((pack) => (
-              <TranslationPackCard key={pack.id} pack={pack} />
-            ))}
-          </div>
-
-          {visiblePacks < filteredPacks.length && (
-            <div className="mt-8 text-center">
-              <Button
-                onClick={() => setVisiblePacks((prev) => Math.min(prev + 6, filteredPacks.length))}
-                className="minecraft-btn"
-              >
-                加载更多
-              </Button>
-            </div>
-          )}
-
-          {filteredPacks.length === 0 && (
-            <div className="text-center py-12">
-              <h3 className="text-xl font-pixel mb-2">未找到翻译包</h3>
-              <p className="text-muted-foreground">尝试调整您的过滤条件或搜索词</p>
-              <Button asChild className="minecraft-btn mt-4">
-                <Link href="/market">清除筛选器</Link>
-              </Button>
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* Back to Top Button */}
-      <BackToTop />
-    </div></>
-  )
+interface PageProps {
+  // `searchParams` prop 在 Next.js 13 App Router 的 page.tsx 中自动提供
+  searchParams: {
+    tag?: string;
+    q?: string; // 假设搜索查询参数名为 'q'
+  };
 }
 
+// 辅助函数：格式化标签以供显示 (在服务器组件和客户端组件中可能都需要)
+function formatTagForDisplay(tagSlug: string): string {
+  try {
+    const decodedTag = decodeURIComponent(tagSlug);
+    return decodedTag.charAt(0).toUpperCase() + decodedTag.slice(1);
+  } catch (error) {
+    // 如果解码失败 (例如，URL参数格式不正确), 返回原始标签或默认值
+    console.error("Error decoding tag slug:", tagSlug, error);
+    return tagSlug.charAt(0).toUpperCase() + tagSlug.slice(1); // 尝试简单格式化
+  }
+}
+
+// --------------------------------------------------------
+// 1. generateMetadata 函数 (用于服务器端生成 <head> 标签)
+// --------------------------------------------------------
+export async function generateMetadata({ searchParams }: PageProps): Promise<Metadata> {
+  const selectedTagFromUrl = searchParams.tag || null;
+  const searchQueryFromUrl = searchParams.q || "";
+
+  let pageTitle = "翻译包市场 | PixelLingual像素语匠";
+  let description = "浏览PixelLingual的Minecraft中文翻译市场。免费下载高质量的游戏内容翻译，提升您的游戏体验。";
+  let keywords = "Minecraft中文翻译, 基岩版翻译包, 免费Minecraft资源, 游戏中文本地化, Minecraft资源市场, 我的世界汉化";
+  const ogUrl = "https://pling.top/market"; // 市场的固定URL
+
+  if (selectedTagFromUrl) {
+    const formattedTag = formatTagForDisplay(selectedTagFromUrl);
+    pageTitle = `${formattedTag}类翻译包 | PixelLingual像素语匠`;
+    description = `浏览PixelLingual的Minecraft的${formattedTag}类别翻译包。找到适合您的高质量Minecraft中文翻译资源。`;
+    keywords = `Minecraft ${formattedTag}翻译包, 中文${formattedTag}资源包, Minecraft基岩版翻译, ${formattedTag}中文本地化, ${formattedTag}翻译`;
+  } else if (searchQueryFromUrl) {
+    pageTitle = `搜索 "${searchQueryFromUrl}" | PixelLingual像素语匠`;
+    description = `在PixelLingual市场搜索Minecraft翻译包：“${searchQueryFromUrl}”。`;
+    keywords = `Minecraft翻译搜索, ${searchQueryFromUrl}, 游戏汉化搜索`;
+  }
+
+  // 默认 OG 图像
+  const ogImage = "/images/market.jpeg";
+
+  return {
+    title: pageTitle,
+    description: description,
+    keywords: keywords,
+    openGraph: {
+      title: pageTitle,
+      description: description,
+      url: ogUrl,
+      images: [
+        {
+          url: ogImage,
+          width: 1920, // 适应你的背景图尺寸
+          height: 400, // 适应你的背景图尺寸
+          alt: "Minecraft marketplace background",
+        },
+      ],
+      type: "website", // 对于主市场页面，通常是 "website" 类型
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: pageTitle,
+      description: description,
+      images: [ogImage],
+    },
+  };
+}
+
+// --------------------------------------------------------
+// 2. 页面组件 (服务器组件)
+// --------------------------------------------------------
+export default async function MarketPage({ searchParams }: PageProps) {
+  const selectedTag = searchParams.tag || null;
+  const searchQuery = searchParams.q || ""; // 假设搜索参数是 'q'
+
+  // 在服务器端执行初始过滤
+  let initialFilteredPacks = ALL_PACKS;
+  if (selectedTag) {
+    initialFilteredPacks = initialFilteredPacks.filter((pack) =>
+      pack.tags.some((tag) => tag.toLowerCase() === selectedTag.toLowerCase())
+    );
+  }
+  if (searchQuery) {
+    const query = searchQuery.toLowerCase();
+    initialFilteredPacks = initialFilteredPacks.filter(
+      (pack) =>
+        pack.title.toLowerCase().includes(query) ||
+        pack.description.toLowerCase().includes(query) ||
+        pack.tags.some((tag) => tag.toLowerCase().includes(query)) ||
+        pack.author.toLowerCase().includes(query) ||
+        pack.studio.toLowerCase().includes(query),
+    );
+  }
+
+  // 获取其他静态或预计算数据
+  const recentPacks = getMostRecentPacks(3); // 服务器端获取
+  const featuredPacks = FEATURED_PACKS; // 直接引用常量
+  const tags = TAGS; // 直接引用常量
+  const studios = STUDIOS; // 直接引用常量
+  const sections = SECTIONS; // 直接引用常量
+
+  // 判断是否处于搜索状态
+  const initialIsSearching = !!searchQuery;
+
+  return (
+    <MarketClient
+      initialFilteredPacks={initialFilteredPacks}
+      initialSelectedTag={selectedTag}
+      initialSearchQuery={searchQuery}
+      initialIsSearching={initialIsSearching}
+      recentPacks={recentPacks}
+      featuredPacks={featuredPacks}
+      tags={tags}
+      studios={studios}
+      sections={sections}
+    />
+  );
+}

--- a/app/market/section/[section]/section-client.tsx
+++ b/app/market/section/[section]/section-client.tsx
@@ -1,0 +1,121 @@
+// components/section-client.tsx
+"use client"; // 👈 标记为客户端组件
+
+import { useState, useEffect, useRef } from "react";
+import Image from "next/image"; // Image 组件通常在客户端使用，但这里用它作为背景图，所以保持
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import TranslationPackCard from "@/components/translation-pack-card";
+// 注意：这里不再需要 getPacksBySectionId, getSectionTitleById
+import { TranslationPack } from "@/data/translation-packs"; // 导入 TranslationPack 类型
+
+interface SectionClientProps {
+  initialSectionPacks: TranslationPack[];
+  initialSectionTitle: string;
+  sectionId: string; // 传入 sectionId 以便在客户端组件中使用，如果需要
+}
+
+export default function SectionClient({
+  initialSectionPacks,
+  initialSectionTitle,
+  sectionId, // 接收 sectionId
+}: SectionClientProps) {
+  // 使用从 props 传入的初始数据初始化状态
+  const [visiblePacks, setVisiblePacks] = useState(18);
+  const [sectionPacks, setSectionPacks] = useState<TranslationPack[]>(initialSectionPacks);
+  const [sectionTitle, setSectionTitle] = useState(initialSectionTitle);
+  const packListRef = useRef<HTMLDivElement>(null);
+
+  // 移除了原始的 useEffect 数据获取逻辑，因为数据现在通过 props 传入
+
+  // 处理无限滚动
+  const handleScroll = () => {
+    if (!packListRef.current) return;
+
+    // 确保只有在用户滚动到底部附近且还有更多包可以加载时才加载
+    // document.documentElement 适用于整个文档的滚动
+    const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
+
+    if (scrollTop + clientHeight >= scrollHeight - 300 && visiblePacks < sectionPacks.length) {
+      setVisiblePacks((prev) => Math.min(prev + 12, sectionPacks.length));
+    }
+  };
+
+  useEffect(() => {
+    // 仅在 sectionPacks 数组不为空时添加滚动事件监听器，避免不必要的监听
+    if (sectionPacks.length > 0) {
+      window.addEventListener("scroll", handleScroll);
+    }
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [sectionPacks, visiblePacks]); // 依赖项包含 sectionPacks 和 visiblePacks
+
+  // 如果 sectionPacks 为空，显示未找到内容
+  if (sectionPacks.length === 0) {
+    return (
+      <div className="container py-20 text-center">
+        <h3 className="text-xl font-pixel mb-2">未找到翻译包</h3>
+        <p className="text-muted-foreground">
+          我们无法在 "{sectionTitle}" 部分找到任何翻译包。
+        </p>
+        <Button asChild className="minecraft-btn mt-4">
+          <Link href="/market">返回市场</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen pb-20">
+      {/* Hero Section */}
+      <section className="relative py-12 overflow-hidden">
+        <div className="absolute inset-0 z-0">
+          <Image
+            src={`/placeholder.svg?height=400&width=1920&text=${sectionTitle}`}
+            alt={`${sectionTitle} translations`}
+            fill
+            className="object-cover opacity-20"
+            priority
+          />
+        </div>
+        <div className="container relative z-10">
+          <Link href="/market" className="inline-flex items-center text-muted-foreground hover:text-primary mb-4">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to Market
+          </Link>
+
+          <div className="max-w-3xl mx-auto text-center space-y-4">
+            <h1 className="text-3xl md:text-4xl font-pixel tracking-tight">
+              <span className="text-primary">{sectionTitle}</span>
+            </h1>
+            <p className="text-muted-foreground">浏览本部分中的所有翻译</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Translation Packs Grid */}
+      <section className="py-8">
+        <div className="container">
+          <div ref={packListRef} className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+            {sectionPacks.slice(0, visiblePacks).map((pack) => (
+              <TranslationPackCard key={pack.id} pack={pack} />
+            ))}
+          </div>
+
+          {visiblePacks < sectionPacks.length && (
+            <div className="mt-8 text-center">
+              <Button
+                onClick={() => setVisiblePacks((prev) => Math.min(prev + 12, sectionPacks.length))}
+                className="minecraft-btn"
+              >
+                加载更多
+              </Button>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/market/studio/[studio]/page.tsx
+++ b/app/market/studio/[studio]/page.tsx
@@ -1,153 +1,110 @@
-"use client"
+import { Metadata } from 'next';
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
 
-import { useState, useEffect, useRef } from "react"
-import Image from "next/image"
-import Link from "next/link"
-import Head from "next/head"
-import { ArrowLeft } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import TranslationPackCard from "@/components/translation-pack-card"
-import { ALL_PACKS, getStudioById } from "@/data/translation-packs"
+// 导入数据源和类型
+import { ALL_PACKS, getStudioById } from "@/data/translation-packs";
+// 导入客户端组件
+import StudioClient from "./studio-client";
 
 interface PageProps {
   params: {
-    studio: string
-  }
+    studio: string; // studio slug, e.g., "mojang-studios"
+  };
 }
 
-export default function StudioPage({ params }: PageProps) {
-  const { studio } = params
-  const [visiblePacks, setVisiblePacks] = useState(18)
-  const [studioPacks, setStudioPacks] = useState([])
-  const [studioInfo, setStudioInfo] = useState(null)
-  const packListRef = useRef<HTMLDivElement>(null)
+// --------------------------------------------------------
+// 1. generateMetadata 函数 (用于服务器端生成 <head> 标签)
+// --------------------------------------------------------
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const studioIdParam = params.studio;
+  const studioInfo = getStudioById(studioIdParam); // 在服务器端获取工作室信息
 
-  useEffect(() => {
-    // Find studio info
-    const foundStudio = getStudioById(studio)
+  let formattedStudioName: string;
+  let description: string;
+  let keywords: string;
+  let ogImage: string = "/placeholder.svg"; // 默认占位符图片
 
-    if (foundStudio) {
-      setStudioInfo(foundStudio)
-
-      // Filter packs by studio
-      const filtered = ALL_PACKS.filter((pack) => pack.studio.toLowerCase() === foundStudio.name.toLowerCase())
-
-      setStudioPacks(filtered)
-      
-      // 设置页面标题
-      document.title = `${foundStudio.name} 工作室翻译包 | PixelLingual像素语匠`
+  if (studioInfo) {
+    formattedStudioName = studioInfo.name;
+    description = `浏览工作室${formattedStudioName}的Minecraft中文翻译包。PixelLingual为您提供高质量的游戏内容翻译。`;
+    keywords = `${formattedStudioName} Minecraft翻译, ${formattedStudioName}中文资源包, Minecraft基岩版翻译, ${formattedStudioName}游戏翻译`;
+    if (studioInfo.logo) {
+      ogImage = studioInfo.logo; // 如果有工作室Logo，使用它
     } else {
-      // 格式化工作室名称以供显示
-      const formattedStudio = studio.replace(/-/g, " ").replace(/\b\w/g, (l) => l.toUpperCase())
-      document.title = `${formattedStudio} 工作室翻译包 | PixelLingual像素语匠`
+      // 如果没有工作室Logo，尝试使用该工作室下第一个翻译包的图片作为Fallback
+      const packsForStudio = ALL_PACKS.filter(pack => pack.studio === studioInfo.id);
+      if (packsForStudio.length > 0 && packsForStudio[0].image) {
+        ogImage = packsForStudio[0].image;
+      }
     }
-  }, [studio])
-
-  // Handle infinite scroll
-  const handleScroll = () => {
-    if (!packListRef.current) return
-
-    const { scrollTop, scrollHeight, clientHeight } = document.documentElement
-    if (scrollTop + clientHeight >= scrollHeight - 300 && visiblePacks < studioPacks.length) {
-      setVisiblePacks((prev) => Math.min(prev + 12, studioPacks.length))
-    }
+  } else {
+    // 如果工作室未找到，根据 slug 格式化名称，并提供通用元数据
+    formattedStudioName = studioIdParam.replace(/-/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
+    description = `您查找的Minecraft工作室“${formattedStudioName}”的翻译包不存在或已被移除。`;
+    keywords = `工作室未找到, Minecraft翻译包, ${formattedStudioName}翻译`;
+    // ogImage 保持为默认的 "/placeholder.svg"
   }
 
-  useEffect(() => {
-    window.addEventListener("scroll", handleScroll)
-    return () => window.removeEventListener("scroll", handleScroll)
-  }, [studioPacks, visiblePacks])
-
-  // Format studio name for display
-  const formattedStudio = studioInfo
-    ? studioInfo.name
-    : studio.replace(/-/g, " ").replace(/\b\w/g, (l) => l.toUpperCase())
-
-  return (
-        <>
-      <Head>
-        <title>{formattedStudio} 工作室翻译包 | PixelLingual像素语匠</title>
-        <meta
-          name="description"
-          content={`浏览工作室${formattedStudio}的Minecraft中文翻译包。PixelLingual为您提供高质量的游戏内容翻译。`}
-        />
-        <meta
-          name="keywords"
-          content={`${formattedStudio} Minecraft翻译, ${formattedStudio}中文资源包, Minecraft基岩版翻译, ${formattedStudio}游戏翻译`}
-        />
-      </Head>
-    <div className="min-h-screen pb-20">
-      {/* Hero Section */}
-      <section className="relative py-12 overflow-hidden">
-        <div className="absolute inset-0 z-0">
-          <Image
-            src={`/placeholder.svg?height=400&width=1920&text=${formattedStudio}`}
-            alt={`${formattedStudio} translations`}
-            fill
-            className="object-cover opacity-20"
-            priority
-          />
-        </div>
-        <div className="container relative z-10">
-          <Link href="/market" className="inline-flex items-center text-muted-foreground hover:text-primary mb-4">
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            返回市场
-          </Link>
-
-          <div className="max-w-3xl mx-auto text-center space-y-4">
-            {studioInfo && (
-              <div className="flex justify-center mb-4">
-                <div className="relative w-24 h-24">
-                  <Image
-                    src={studioInfo.logo || "/placeholder.svg"}
-                    alt={studioInfo.name}
-                    fill
-                    className="object-contain pixelated"
-                  />
-                </div>
-              </div>
-            )}
-            <h1 className="text-3xl md:text-4xl font-pixel tracking-tight">
-              <span className="text-primary">{formattedStudio}</span> Translations
-            </h1>
-            <p className="text-muted-foreground">浏览全部为 {formattedStudio} 地图工作室所创作的翻译包</p>
-          </div>
-        </div>
-      </section>
-
-      {/* Translation Packs Grid */}
-      <section className="py-8">
-        <div className="container">
-          <div ref={packListRef} className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-            {studioPacks.slice(0, visiblePacks).map((pack) => (
-              <TranslationPackCard key={pack.id} pack={pack} />
-            ))}
-          </div>
-
-          {visiblePacks < studioPacks.length && (
-            <div className="mt-8 text-center">
-              <Button
-                onClick={() => setVisiblePacks((prev) => Math.min(prev + 12, studioPacks.length))}
-                className="minecraft-btn"
-              >
-                加载更多
-              </Button>
-            </div>
-          )}
-
-          {studioPacks.length === 0 && (
-            <div className="text-center py-12">
-              <h3 className="text-xl font-pixel mb-2">未找到工作室（工作室详情页仍未完工，敬请期待）</h3>
-              <p className="text-muted-foreground">我们无法找到任何为 "{formattedStudio}" 工作室所创作的翻译包，也许工作室已改名或不存在？</p>
-              <Button asChild className="minecraft-btn mt-4">
-                <Link href="/market">返回市场</Link>
-              </Button>
-            </div>
-          )}
-        </div>
-      </section>
-    </div>
-    </>
-  )
+  return {
+    title: `${formattedStudioName} 工作室翻译包 | PixelLingual像素语匠`,
+    description: description,
+    keywords: keywords,
+    openGraph: {
+      title: `${formattedStudioName} 工作室翻译包 - PixelLingual`,
+      description: description,
+      images: [
+        {
+          url: ogImage,
+          width: 1200, // 建议的 OG 图片宽度
+          height: 630, // 建议的 OG 图片高度
+          alt: `${formattedStudioName} Translations`,
+        }
+      ],
+      type: "website", // 对于分类或工作室页面，通常是 website 类型
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${formattedStudioName} 工作室翻译包 - PixelLingual`,
+      description: description,
+      images: [ogImage],
+    },
+  };
 }
 
+// --------------------------------------------------------
+// 2. 页面组件 (服务器组件)
+// --------------------------------------------------------
+export default async function StudioPage({ params }: PageProps) {
+  const { studio: studioIdParam } = params;
+
+  const studioInfo = getStudioById(studioIdParam); // 在服务器端获取工作室信息
+
+  // 如果工作室信息完全不存在，直接在服务器端渲染一个“未找到”页面
+  // 这对于搜索引擎和用户体验更好，因为它避免了客户端的二次加载
+  if (!studioInfo) {
+    const formattedStudioName = studioIdParam.replace(/-/g, " ").replace(/\b\w/g, (l) => l.toUpperCase());
+    return (
+      <div className="container py-20 text-center">
+        <h3 className="text-xl font-pixel mb-2">工作室未找到</h3>
+        <p className="text-muted-foreground">我们无法找到名为 "{formattedStudioName}" 的工作室。</p>
+        <Button asChild className="minecraft-btn mt-4">
+          <Link href="/market">返回市场</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  // 如果工作室存在，则过滤出该工作室的所有翻译包
+  // ALL_PACKS 应该是一个常量数组，可以直接在服务器组件中使用
+  const studioPacks = ALL_PACKS.filter((pack) => pack.studio === studioInfo.id);
+
+  // 将获取到的数据作为 props 传递给客户端组件
+  return (
+    <StudioClient
+      initialStudioInfo={studioInfo} // 确保 studioInfo 不为 null
+      initialStudioPacks={studioPacks}
+      studioIdParam={studioIdParam} // 传递原始参数，尽管在客户端组件中可能不再需要
+    />
+  );
+}

--- a/app/market/studio/[studio]/studio-client.tsx
+++ b/app/market/studio/[studio]/studio-client.tsx
@@ -1,0 +1,130 @@
+"use client"; 
+
+import { useState, useEffect, useRef } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import TranslationPackCard from "@/components/translation-pack-card";
+// 导入 Studio 和 TranslationPack 类型
+import { Studio, TranslationPack } from "@/data/translation-packs";
+
+interface StudioClientProps {
+  initialStudioInfo: Studio; // 这里我们知道 studioInfo 不会是 null，因为服务器组件已处理
+  initialStudioPacks: TranslationPack[];
+  studioIdParam: string; // 原始的 studio slug，用于在没有 studioInfo 时格式化显示
+}
+
+export default function StudioClient({
+  initialStudioInfo,
+  initialStudioPacks,
+  studioIdParam,
+}: StudioClientProps) {
+  const [visiblePacks, setVisiblePacks] = useState(18);
+  // 使用从 props 传入的初始数据初始化状态
+  const [studioPacks, setStudioPacks] = useState<TranslationPack[]>(initialStudioPacks);
+  const [studioInfo, setStudioInfo] = useState<Studio>(initialStudioInfo); // studioInfo 已经确保不是 null
+  const packListRef = useRef<HTMLDivElement>(null);
+
+  // 移除了原始的 useEffect 数据获取逻辑，因为数据现在通过 props 传入
+
+  // 处理无限滚动
+  const handleScroll = () => {
+    if (!packListRef.current) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
+    if (scrollTop + clientHeight >= scrollHeight - 300 && visiblePacks < studioPacks.length) {
+      setVisiblePacks((prev) => Math.min(prev + 12, studioPacks.length));
+    }
+  };
+
+  useEffect(() => {
+    // 仅在 studioPacks 数组不为空时添加滚动事件监听器
+    if (studioPacks.length > 0) {
+      window.addEventListener("scroll", handleScroll);
+    }
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [studioPacks, visiblePacks]);
+
+  // 格式化工作室名称以供显示
+  // 在这里，studioInfo 肯定存在，所以可以直接使用 studioInfo.name
+  const formattedStudio = studioInfo.name;
+
+  // 注意：服务器组件已经处理了 studioInfo 为 null 的情况
+  // 所以这里不再需要检查 !studioInfo，直接渲染页面内容
+  return (
+    <div className="min-h-screen pb-20">
+      {/* Hero Section */}
+      <section className="relative py-12 overflow-hidden">
+        <div className="absolute inset-0 z-0">
+          <Image
+            src={`/placeholder.svg?height=400&width=1920&text=${formattedStudio}`}
+            alt={`${formattedStudio} translations`}
+            fill
+            className="object-cover opacity-20"
+            priority
+          />
+        </div>
+        <div className="container relative z-10">
+          <Link href="/market" className="inline-flex items-center text-muted-foreground hover:text-primary mb-4">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            返回市场
+          </Link>
+
+          <div className="max-w-3xl mx-auto text-center space-y-4">
+            {studioInfo && ( // studioInfo 已经确保不是 null，这个检查可以简化，但保留以防万一
+              <div className="flex justify-center mb-4">
+                <div className="relative w-24 h-24">
+                  <Image
+                    src={studioInfo.logo || "/placeholder.svg"}
+                    alt={studioInfo.name}
+                    fill
+                    className="object-contain pixelated"
+                  />
+                </div>
+              </div>
+            )}
+            <h1 className="text-3xl md:text-4xl font-pixel tracking-tight">
+              <span className="text-primary">{formattedStudio}</span> Translations
+            </h1>
+            <p className="text-muted-foreground">浏览全部为 {formattedStudio} 地图工作室所创作的翻译包</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Translation Packs Grid */}
+      <section className="py-8">
+        <div className="container">
+          <div ref={packListRef} className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+            {studioPacks.slice(0, visiblePacks).map((pack) => (
+              <TranslationPackCard key={pack.id} pack={pack} />
+            ))}
+          </div>
+
+          {visiblePacks < studioPacks.length && (
+            <div className="mt-8 text-center">
+              <Button
+                onClick={() => setVisiblePacks((prev) => Math.min(prev + 12, studioPacks.length))}
+                className="minecraft-btn"
+              >
+                加载更多
+              </Button>
+            </div>
+          )}
+
+          {studioPacks.length === 0 && (
+            <div className="text-center py-12">
+              <h3 className="text-xl font-pixel mb-2">这个工作室走丢啦</h3>
+              <p className="text-muted-foreground">我们无法找到任何为 "{formattedStudio}" 工作室所创作的翻译包，也许暂无可用翻译包或工作室暂无翻译包？</p>
+              <Button asChild className="minecraft-btn mt-4">
+                <Link href="/market">返回市场</Link>
+              </Button>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/market/tag/[tag]/tag-client.tsx
+++ b/app/market/tag/[tag]/tag-client.tsx
@@ -1,0 +1,112 @@
+"use client"; 
+
+import { useState, useEffect, useRef } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import TranslationPackCard from "@/components/translation-pack-card";
+import { TranslationPack } from "@/data/translation-packs"; // 导入 TranslationPack 类型
+
+interface TagClientProps {
+  initialTagPacks: TranslationPack[];
+  formattedTag: string;
+}
+
+export default function TagClient({ initialTagPacks, formattedTag }: TagClientProps) {
+  const [visiblePacks, setVisiblePacks] = useState(12);
+  // 使用从 props 传入的初始数据初始化状态
+  const [tagPacks, setTagPacks] = useState<TranslationPack[]>(initialTagPacks);
+  const packListRef = useRef<HTMLDivElement>(null);
+
+  // 移除了原始的 useEffect 数据获取逻辑，因为数据现在通过 props 传入
+
+  // 处理无限滚动
+  const handleScroll = () => {
+    if (!packListRef.current) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
+    // 检查是否滚动到距离底部 300px 范围内，并且还有更多包可以加载
+    if (scrollTop + clientHeight >= scrollHeight - 300 && visiblePacks < tagPacks.length) {
+      setVisiblePacks((prev) => Math.min(prev + 6, tagPacks.length));
+    }
+  };
+
+  useEffect(() => {
+    // 仅在 tagPacks 数组不为空时添加滚动事件监听器
+    if (tagPacks.length > 0) {
+      window.addEventListener("scroll", handleScroll);
+    }
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [tagPacks, visiblePacks]); // 依赖项确保监听器在状态变化时正确更新
+
+  // 注意：服务器组件已经处理了 tagPacks 为空的情况，
+  // 这里的检查是为了客户端侧的极少数边缘情况，或者作为后续交互导致数据变化后的回退。
+  if (tagPacks.length === 0) {
+    return (
+      <div className="container py-20 text-center">
+        <h3 className="text-xl font-pixel mb-2">未找到翻译包</h3>
+        <p className="text-muted-foreground">
+          我们无法找到任何带有标签"{formattedTag}"的翻译包。
+        </p>
+        <Button asChild className="minecraft-btn mt-4">
+          <Link href="/market">返回市场</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen pb-20">
+      {/* Hero Section */}
+      <section className="relative py-12 overflow-hidden">
+        <div className="absolute inset-0 z-0">
+          <Image
+            src={`/placeholder.svg?height=400&width=1920&text=${formattedTag} Maps`}
+            alt={`${formattedTag} maps`}
+            fill
+            className="object-cover opacity-20"
+            priority
+          />
+        </div>
+        <div className="container relative z-10">
+          <Link href="/market" className="inline-flex items-center text-muted-foreground hover:text-primary mb-4">
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            回到市场
+          </Link>
+
+          <div className="max-w-3xl mx-auto text-center space-y-4">
+            <h1 className="text-3xl md:text-4xl font-pixel tracking-tight">
+              <span className="text-primary">{formattedTag}</span> 翻译包
+            </h1>
+            <p className="text-muted-foreground">浏览我们所有{formattedTag.toLowerCase()}的翻译包</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Translation Packs Grid */}
+      <section className="py-8">
+        <div className="container">
+          <div ref={packListRef} className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
+            {tagPacks.slice(0, visiblePacks).map((pack) => (
+              <TranslationPackCard key={pack.id} pack={pack} />
+            ))}
+          </div>
+
+          {visiblePacks < tagPacks.length && (
+            <div className="mt-8 text-center">
+              <Button
+                onClick={() => setVisiblePacks((prev) => Math.min(prev + 6, tagPacks.length))}
+                className="minecraft-btn"
+              >
+                加载更多
+              </Button>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
+import { BackButton } from "@/components/back-btn"
 import { Home, Search } from "lucide-react"
 import type { Metadata } from "next"
 
@@ -58,16 +59,12 @@ export default function NotFoundPage() {
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
-            <Button asChild className="minecraft-btn">
-              <Link href="/">
-                <span><span><Home className="mr-2 h-4 w-4" /></span>
-                返回首页</span>
-              </Link>
-            </Button>
+            <BackButton>
+            </BackButton>
             <Button asChild variant="outline">
               <Link href="/market">
-                <Search className="mr-2 h-4 w-4" />
-                浏览翻译包
+                <Home className="mr-2 h-4 w-4" />
+                返回首页
               </Link>
             </Button>
           </div>

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
   description: "通过访问或使用本服务，您同意受本条款约束。如果您不同意本条款的任何部分，请您立即退出 PixelLingual 网站并暂停使用 PixelLingual 的一切服务。",
   openGraph: {
     url: "https://pling.top/terms",
-    title: "服务条款 | Pixellingual像素语匠",
+    title: "服务条款 - Pixellingual像素语匠",
     description: "通过访问或使用本服务，您同意受本条款约束。如果您不同意本条款的任何部分，请您立即退出 PixelLingual 网站并暂停使用 PixelLingual 的一切服务。",
   },
   twitter: {

--- a/components/back-btn.tsx
+++ b/components/back-btn.tsx
@@ -1,0 +1,15 @@
+"use client"; // 组件必须是客户端组件
+
+import { useRouter } from "next/navigation";
+
+export function BackButton() {
+  const router = useRouter();
+
+  return (
+    <button
+      onClick={() => router.back()} className="minecraft-btn"
+    >
+      返回上一页
+    </button>
+  );
+}


### PR DESCRIPTION
在本分支中，重点修改了部分单一CSR页面的渲染逻辑，改为了CSR与SSR搭配的渲染方式，以优化性能及正确配置Head的相关内容。
具体修改如下：
# BUG修复
- 图标目前可以与内容保持与一行了：#1
- 现在详情页可以正确加载相关标题，并增加了部分忽略设置的页面标题： #18 
- 目前几乎所有页面OpenGraph均可正确显示。因图片和twitter内容未完全设置完毕，故该Issue仍处于open状态：#16
- 现已删除多余的背景颜色。#12 
- 现在工作室的翻译包可以正常显示了。原先由于studio的id匹配规则有误导致带有空格的工作室无法正确匹配：#3
# 主要修改
## 有关报错页面
现在404页面的下方按钮分别改为了“返回上一页”和“返回首页”，以符合使用习惯。
## 单一CSR页面修改
现已将如/market, /market/id, /market/studio, /market/section, /market/tag 等页面由完全CSR改为了CSR + SSR搭配的方式进行渲染，减少浏览器解析时间，提升首屏加载速度，优化SEO及减轻客户端的负担。
## 原单一CSR页面内的部分代码逻辑
修改了一些原单一CSR页面的代码逻辑，增加了部分意外情况判断并优化性能。